### PR TITLE
feat: add `isNew` option to repositories for handling entity creation state and concurrency checks

### DIFF
--- a/apps/api/src/modules/parking/application/command-handlers/__tests/create-parking-addon.command-handler.spec.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/__tests/create-parking-addon.command-handler.spec.ts
@@ -56,7 +56,10 @@ describe('CreateParkingAddonCommandHandler', () => {
 
     expect(result).toBeDefined();
     expect(repository.findByCode).toHaveBeenCalledWith('PA1');
-    expect(repository.save).toHaveBeenCalledWith(expect.any(ParkingAddon));
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.any(ParkingAddon),
+      expect.objectContaining({ isNew: true }),
+    );
     expect(publisher.mergeObjectContext).toHaveBeenCalled();
   });
 

--- a/apps/api/src/modules/parking/application/command-handlers/__tests/create-parking.command-handler.spec.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/__tests/create-parking.command-handler.spec.ts
@@ -55,7 +55,10 @@ describe('CreateParkingCommandHandler', () => {
     expect(publisher.mergeObjectContext).toHaveBeenCalledWith(
       expect.any(Parking),
     );
-    expect(repository.save).toHaveBeenCalledWith(expect.any(Parking));
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.any(Parking),
+      expect.objectContaining({ isNew: true }),
+    );
     /* eslint-enable @typescript-eslint/unbound-method */
     const savedParking = repository.save.mock.calls[0][0];
     expect(savedParking.getName().value).toBe(command.name);

--- a/apps/api/src/modules/parking/application/command-handlers/__tests/create-place-type.command-handler.spec.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/__tests/create-place-type.command-handler.spec.ts
@@ -47,7 +47,10 @@ describe('CreatePlaceTypeCommandHandler', () => {
     expect(publisher.mergeObjectContext).toHaveBeenCalledWith(
       expect.any(PlaceType),
     );
-    expect(repository.save).toHaveBeenCalledWith(expect.any(PlaceType));
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.any(PlaceType),
+      expect.objectContaining({ isNew: true }),
+    );
     /* eslint-enable @typescript-eslint/unbound-method */
     const savedPlaceType = repository.save.mock.calls[0][0];
     expect(savedPlaceType.getName().value).toBe('Standard');

--- a/apps/api/src/modules/parking/application/command-handlers/__tests/create-place.command-handler.spec.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/__tests/create-place.command-handler.spec.ts
@@ -53,7 +53,10 @@ describe('CreatePlaceCommandHandler', () => {
     expect(publisher.mergeObjectContext).toHaveBeenCalledWith(
       expect.any(Place),
     );
-    expect(repository.save).toHaveBeenCalledWith(expect.any(Place));
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.any(Place),
+      expect.objectContaining({ isNew: true }),
+    );
     /* eslint-enable @typescript-eslint/unbound-method */
     const savedPlace = repository.save.mock.calls[0][0];
     expect(savedPlace.getName().value).toBe(command.name);

--- a/apps/api/src/modules/parking/application/command-handlers/create-parking-addon.command-handler.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/create-parking-addon.command-handler.ts
@@ -30,7 +30,7 @@ export class CreateParkingAddonCommandHandler implements ICommandHandler<
       ParkingAddon.create(code, name, price),
     );
 
-    await this.parkingAddonRepository.save(parkingAddon);
+    await this.parkingAddonRepository.save(parkingAddon, { isNew: true });
     parkingAddon.commit();
 
     return parkingAddon.getId().value;

--- a/apps/api/src/modules/parking/application/command-handlers/create-parking.command-handler.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/create-parking.command-handler.ts
@@ -20,7 +20,7 @@ export class CreateParkingCommandHandler implements ICommandHandler<
       Parking.create(ownerId, name, address, { longitude, latitude }, placeId),
     );
 
-    await this.parkingRepository.save(parking);
+    await this.parkingRepository.save(parking, { isNew: true });
     parking.commit();
 
     return parking.getId().value;

--- a/apps/api/src/modules/parking/application/command-handlers/create-place-type-command-handler.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/create-place-type-command-handler.ts
@@ -20,7 +20,7 @@ export class CreatePlaceTypeCommandHandler implements ICommandHandler<
       PlaceType.create(name),
     );
 
-    await this.placeTypeRepository.save(placeType);
+    await this.placeTypeRepository.save(placeType, { isNew: true });
     placeType.commit();
 
     return placeType.getId().value;

--- a/apps/api/src/modules/parking/application/command-handlers/create-place.command-handler.ts
+++ b/apps/api/src/modules/parking/application/command-handlers/create-place.command-handler.ts
@@ -20,7 +20,7 @@ export class CreatePlaceCommandHandler implements ICommandHandler<
       Place.create(name, { latitude, longitude }, address, active, placeTypeId),
     );
 
-    await this.placeRepository.save(place);
+    await this.placeRepository.save(place, { isNew: true });
     place.commit();
 
     return place.getId().value;

--- a/apps/api/src/modules/parking/application/event-handlers/index.ts
+++ b/apps/api/src/modules/parking/application/event-handlers/index.ts
@@ -11,6 +11,10 @@ import { PlaceUpdatedEventHandler } from './place-updated.event-handler';
 import { ParkingFeatureCreatedEventHandler } from './parking-feature-created.event-handler';
 import { ParkingFeatureUpdatedEventHandler } from './parking-feature-updated.event-handler';
 import { ParkingFeatureDeletedEventHandler } from './parking-feature-deleted.event-handler';
+import { ParkingSpotCreatedEventHandler } from './parking-spot-created.event-handler';
+import { ParkingSpotUpdatedEventHandler } from './parking-spot-updated.event-handler';
+import { ParkingSpotActivatedEventHandler } from './parking-spot-activated.event-handler';
+import { ParkingSpotDeactivatedEventHandler } from './parking-spot-deactivated.event-handler';
 
 export const eventHandlers = [
   PlaceTypeDeletedEventHandler,
@@ -26,4 +30,8 @@ export const eventHandlers = [
   ParkingFeatureCreatedEventHandler,
   ParkingFeatureUpdatedEventHandler,
   ParkingFeatureDeletedEventHandler,
+  ParkingSpotCreatedEventHandler,
+  ParkingSpotUpdatedEventHandler,
+  ParkingSpotActivatedEventHandler,
+  ParkingSpotDeactivatedEventHandler,
 ];

--- a/apps/api/src/modules/parking/application/event-handlers/parking-spot-activated.event-handler.ts
+++ b/apps/api/src/modules/parking/application/event-handlers/parking-spot-activated.event-handler.ts
@@ -1,0 +1,12 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { Logger } from '@nestjs/common';
+import { ParkingSpotActivatedEvent } from '../../domain/events/parking-spot-activated.event';
+
+@EventsHandler(ParkingSpotActivatedEvent)
+export class ParkingSpotActivatedEventHandler implements IEventHandler<ParkingSpotActivatedEvent> {
+  private readonly logger = new Logger(ParkingSpotActivatedEventHandler.name);
+
+  handle(event: ParkingSpotActivatedEvent) {
+    this.logger.log(`Parking spot activated: ${event.id}`);
+  }
+}

--- a/apps/api/src/modules/parking/application/event-handlers/parking-spot-created.event-handler.ts
+++ b/apps/api/src/modules/parking/application/event-handlers/parking-spot-created.event-handler.ts
@@ -1,0 +1,12 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { Logger } from '@nestjs/common';
+import { ParkingSpotCreatedEvent } from '../../domain/events/parking-spot-created.event';
+
+@EventsHandler(ParkingSpotCreatedEvent)
+export class ParkingSpotCreatedEventHandler implements IEventHandler<ParkingSpotCreatedEvent> {
+  private readonly logger = new Logger(ParkingSpotCreatedEventHandler.name);
+
+  handle(event: ParkingSpotCreatedEvent) {
+    this.logger.log(`Parking spot created: ${event.id}`);
+  }
+}

--- a/apps/api/src/modules/parking/application/event-handlers/parking-spot-deactivated.event-handler.ts
+++ b/apps/api/src/modules/parking/application/event-handlers/parking-spot-deactivated.event-handler.ts
@@ -1,0 +1,12 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { Logger } from '@nestjs/common';
+import { ParkingSpotDeactivatedEvent } from '../../domain/events/parking-spot-deactivated.event';
+
+@EventsHandler(ParkingSpotDeactivatedEvent)
+export class ParkingSpotDeactivatedEventHandler implements IEventHandler<ParkingSpotDeactivatedEvent> {
+  private readonly logger = new Logger(ParkingSpotDeactivatedEventHandler.name);
+
+  handle(event: ParkingSpotDeactivatedEvent) {
+    this.logger.log(`Parking spot deactivated: ${event.id}`);
+  }
+}

--- a/apps/api/src/modules/parking/application/event-handlers/parking-spot-updated.event-handler.ts
+++ b/apps/api/src/modules/parking/application/event-handlers/parking-spot-updated.event-handler.ts
@@ -1,0 +1,12 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { Logger } from '@nestjs/common';
+import { ParkingSpotUpdatedEvent } from '../../domain/events/parking-spot-updated.event';
+
+@EventsHandler(ParkingSpotUpdatedEvent)
+export class ParkingSpotUpdatedEventHandler implements IEventHandler<ParkingSpotUpdatedEvent> {
+  private readonly logger = new Logger(ParkingSpotUpdatedEventHandler.name);
+
+  handle(event: ParkingSpotUpdatedEvent) {
+    this.logger.log(`Parking spot updated: ${event.id}`);
+  }
+}

--- a/apps/api/src/modules/parking/application/ports/parking-addon.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/parking-addon.repository.ts
@@ -2,7 +2,10 @@ import { ParkingAddon } from '../../domain/parking-addon';
 import { PrismaTx } from '../../../../shared/prisma/types';
 
 export abstract class ParkingAddonRepository {
-  abstract save(parkingAddon: ParkingAddon, tx?: PrismaTx): Promise<void>;
+  abstract save(
+    parkingAddon: ParkingAddon,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<ParkingAddon | null>;
   abstract findByCode(
     code: string,

--- a/apps/api/src/modules/parking/application/ports/parking-addon.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/parking-addon.repository.ts
@@ -1,10 +1,11 @@
 import { ParkingAddon } from '../../domain/parking-addon';
 import { PrismaTx } from '../../../../shared/prisma/types';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 export abstract class ParkingAddonRepository {
   abstract save(
     parkingAddon: ParkingAddon,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<ParkingAddon | null>;
   abstract findByCode(

--- a/apps/api/src/modules/parking/application/ports/parking-feature.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/parking-feature.repository.ts
@@ -1,10 +1,11 @@
 import { ParkingFeature } from '../../domain/parking-feature';
 import { PrismaTx } from '../../../../shared/prisma/types';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 export abstract class ParkingFeatureRepository {
   abstract save(
     parkingFeature: ParkingFeature,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<ParkingFeature | null>;
   abstract delete(id: string, version: number, tx?: PrismaTx): Promise<void>;

--- a/apps/api/src/modules/parking/application/ports/parking-spot.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/parking-spot.repository.ts
@@ -1,10 +1,11 @@
 import { ParkingSpot } from '../../domain/parking-spot';
 import { PrismaTx } from '../../../../shared/prisma/types';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 export abstract class ParkingSpotRepository {
   abstract save(
     parkingSpot: ParkingSpot,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<ParkingSpot | null>;
 }

--- a/apps/api/src/modules/parking/application/ports/parking.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/parking.repository.ts
@@ -2,6 +2,9 @@ import { Parking } from '../../domain/parking';
 import { PrismaTx } from '../../../../shared/prisma/types';
 
 export abstract class ParkingRepository {
-  abstract save(parking: Parking, tx?: PrismaTx): Promise<void>;
+  abstract save(
+    parking: Parking,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<Parking | null>;
 }

--- a/apps/api/src/modules/parking/application/ports/parking.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/parking.repository.ts
@@ -1,10 +1,11 @@
 import { Parking } from '../../domain/parking';
 import { PrismaTx } from '../../../../shared/prisma/types';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 export abstract class ParkingRepository {
   abstract save(
     parking: Parking,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<Parking | null>;
 }

--- a/apps/api/src/modules/parking/application/ports/place-type.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/place-type.repository.ts
@@ -2,7 +2,10 @@ import { PlaceType } from '../../domain/place-type';
 import { PrismaTx } from '../../../../shared/prisma/types';
 
 export abstract class PlaceTypeRepository {
-  abstract save(placeType: PlaceType, tx?: PrismaTx): Promise<void>;
+  abstract save(
+    placeType: PlaceType,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<PlaceType | null>;
   abstract delete(id: string, version: number, tx?: PrismaTx): Promise<void>;
 }

--- a/apps/api/src/modules/parking/application/ports/place-type.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/place-type.repository.ts
@@ -1,10 +1,11 @@
 import { PlaceType } from '../../domain/place-type';
 import { PrismaTx } from '../../../../shared/prisma/types';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 export abstract class PlaceTypeRepository {
   abstract save(
     placeType: PlaceType,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<PlaceType | null>;
   abstract delete(id: string, version: number, tx?: PrismaTx): Promise<void>;

--- a/apps/api/src/modules/parking/application/ports/place.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/place.repository.ts
@@ -1,10 +1,8 @@
 import { Place } from '../../domain/place';
 import { PrismaTx } from '../../../../shared/prisma/types';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 export abstract class PlaceRepository {
-  abstract save(
-    place: Place,
-    options?: { isNew?: boolean; tx?: PrismaTx },
-  ): Promise<void>;
+  abstract save(place: Place, options?: RepositorySaveOptions): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<Place | null>;
 }

--- a/apps/api/src/modules/parking/application/ports/place.repository.ts
+++ b/apps/api/src/modules/parking/application/ports/place.repository.ts
@@ -2,6 +2,9 @@ import { Place } from '../../domain/place';
 import { PrismaTx } from '../../../../shared/prisma/types';
 
 export abstract class PlaceRepository {
-  abstract save(place: Place, tx?: PrismaTx): Promise<void>;
+  abstract save(
+    place: Place,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void>;
   abstract findById(id: string, tx?: PrismaTx): Promise<Place | null>;
 }

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-addon.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-addon.repository.ts
@@ -45,6 +45,10 @@ export class PrismaParkingAddonRepository implements ParkingAddonRepository {
       return;
     }
 
+    if (isNew) {
+      throw new ConcurrencyError('ParkingAddon', id);
+    }
+
     try {
       await prisma.parkingAddon.update({
         where: {

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-addon.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-addon.repository.ts
@@ -9,6 +9,7 @@ import { ParkingAddonName } from '../../domain/value-objects/parking-addon-name'
 import { Money } from '../../domain/value-objects/money';
 import { AggregateVersion } from '../../../../shared/value-objects/aggregate-version';
 import { ConcurrencyError } from '../../../../shared/errors';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 @Injectable()
 export class PrismaParkingAddonRepository implements ParkingAddonRepository {
@@ -16,7 +17,7 @@ export class PrismaParkingAddonRepository implements ParkingAddonRepository {
 
   async save(
     parkingAddon: ParkingAddon,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void> {
     const prisma = options?.tx || this.prismaService;
     const id = parkingAddon.getId().value;

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-addon.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-addon.repository.ts
@@ -14,23 +14,24 @@ import { ConcurrencyError } from '../../../../shared/errors';
 export class PrismaParkingAddonRepository implements ParkingAddonRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async save(parkingAddon: ParkingAddon, tx?: PrismaTx): Promise<void> {
-    const prisma = tx || this.prismaService;
+  async save(
+    parkingAddon: ParkingAddon,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void> {
+    const prisma = options?.tx || this.prismaService;
     const id = parkingAddon.getId().value;
     const currentVersion = parkingAddon.getVersion().value;
+    const isNew = options?.isNew ?? false;
 
     const record = await prisma.parkingAddon.findUnique({
       where: { id },
     });
 
-    // If record does not exist and version > 1, it means the aggregate existed before
-    // and was likely deleted concurrently -> do not recreate, throw concurrency error
     if (!record) {
-      if (currentVersion > 1) {
+      if (!isNew) {
         throw new ConcurrencyError('ParkingAddon', id);
       }
 
-      // Only allow create when we're on the first version (new aggregate)
       await prisma.parkingAddon.create({
         data: {
           id: parkingAddon.getId().value,

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-feature.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-feature.repository.ts
@@ -8,6 +8,7 @@ import { ParkingFeatureName } from '../../domain/value-objects/parking-feature-n
 import { ParkingFeatureLevel } from '../../domain/value-objects/parking-feature-level';
 import { AggregateVersion } from '../../../../shared/value-objects/aggregate-version';
 import { ConcurrencyError } from '../../../../shared/errors';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 @Injectable()
 export class PrismaParkingFeatureRepository implements ParkingFeatureRepository {
@@ -15,7 +16,7 @@ export class PrismaParkingFeatureRepository implements ParkingFeatureRepository 
 
   async save(
     parkingFeature: ParkingFeature,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void> {
     const prisma = options?.tx || this.prismaService;
     const isNew = options?.isNew ?? false;

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-spot.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking-spot.repository.ts
@@ -9,6 +9,7 @@ import { Money } from '../../domain/value-objects/money';
 import { ParkingFeatureId } from '../../domain/value-objects/parking-feature-id';
 import { AggregateVersion } from '../../../../shared/value-objects/aggregate-version';
 import { ConcurrencyError } from '../../../../shared/errors';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 @Injectable()
 export class PrismaParkingSpotRepository implements ParkingSpotRepository {
@@ -16,7 +17,7 @@ export class PrismaParkingSpotRepository implements ParkingSpotRepository {
 
   async save(
     parkingSpot: ParkingSpot,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void> {
     const prisma = options?.tx || this.prismaService;
     const id = parkingSpot.getId().value;

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking.repository.ts
@@ -19,10 +19,14 @@ import { ConcurrencyError } from '../../../../shared/errors';
 export class PrismaParkingRepository implements ParkingRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async save(parking: Parking, tx?: PrismaTx): Promise<void> {
-    const prisma = tx ?? this.prismaService;
+  async save(
+    parking: Parking,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void> {
+    const prisma = options?.tx ?? this.prismaService;
     const id = parking.getId().value;
     const currentVersion = parking.getVersion().value;
+    const isNew = options?.isNew ?? false;
 
     const record = await prisma.parking.findUnique({
       where: { id },
@@ -36,6 +40,10 @@ export class PrismaParkingRepository implements ParkingRepository {
       .map((id) => ({ id: id.value }));
 
     if (!record) {
+      if (!isNew) {
+        throw new ConcurrencyError('Parking', id);
+      }
+
       await prisma.parking.create({
         data: {
           id,

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-parking.repository.ts
@@ -14,15 +14,13 @@ import { ParkingAddonId } from '../../domain/value-objects/parking-addon-id';
 import { PlaceId } from '../../domain/value-objects/place-id';
 import { AggregateVersion } from '../../../../shared/value-objects/aggregate-version';
 import { ConcurrencyError } from '../../../../shared/errors';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 @Injectable()
 export class PrismaParkingRepository implements ParkingRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async save(
-    parking: Parking,
-    options?: { isNew?: boolean; tx?: PrismaTx },
-  ): Promise<void> {
+  async save(parking: Parking, options?: RepositorySaveOptions): Promise<void> {
     const prisma = options?.tx ?? this.prismaService;
     const id = parking.getId().value;
     const currentVersion = parking.getVersion().value;

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-place-type.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-place-type.repository.ts
@@ -7,6 +7,7 @@ import { PlaceTypeId } from '../../domain/value-objects/place-type-id';
 import { PlaceTypeName } from '../../domain/value-objects/place-type-name';
 import { AggregateVersion } from '../../../../shared/value-objects/aggregate-version';
 import { ConcurrencyError } from '../../../../shared/errors';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 @Injectable()
 export class PrismaPlaceTypeRepository implements PlaceTypeRepository {
@@ -14,7 +15,7 @@ export class PrismaPlaceTypeRepository implements PlaceTypeRepository {
 
   async save(
     placeType: PlaceType,
-    options?: { isNew?: boolean; tx?: PrismaTx },
+    options?: RepositorySaveOptions,
   ): Promise<void> {
     const prisma = options?.tx ?? this.prismaService;
     const id = placeType.getId().value;
@@ -26,7 +27,7 @@ export class PrismaPlaceTypeRepository implements PlaceTypeRepository {
     });
 
     if (!record) {
-      if (isNew) {
+      if (!isNew) {
         throw new ConcurrencyError('PlaceType', id);
       }
 

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-place-type.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-place-type.repository.ts
@@ -12,17 +12,21 @@ import { ConcurrencyError } from '../../../../shared/errors';
 export class PrismaPlaceTypeRepository implements PlaceTypeRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async save(placeType: PlaceType, tx?: PrismaTx): Promise<void> {
-    const prisma = tx ?? this.prismaService;
+  async save(
+    placeType: PlaceType,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void> {
+    const prisma = options?.tx ?? this.prismaService;
     const id = placeType.getId().value;
     const currentVersion = placeType.getVersion().value;
+    const isNew = options?.isNew ?? false;
 
     const record = await prisma.placeType.findUnique({
       where: { id },
     });
 
     if (!record) {
-      if (currentVersion > 1) {
+      if (isNew) {
         throw new ConcurrencyError('PlaceType', id);
       }
 

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-place.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-place.repository.ts
@@ -10,15 +10,13 @@ import { Address } from '../../domain/value-objects/address';
 import { PlaceTypeId } from '../../domain/value-objects/place-type-id';
 import { AggregateVersion } from '../../../../shared/value-objects/aggregate-version';
 import { ConcurrencyError } from '../../../../shared/errors';
+import { RepositorySaveOptions } from '../../../../shared/types';
 
 @Injectable()
 export class PrismaPlaceRepository implements PlaceRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async save(
-    place: Place,
-    options?: { isNew?: boolean; tx?: PrismaTx },
-  ): Promise<void> {
+  async save(place: Place, options?: RepositorySaveOptions): Promise<void> {
     const prisma = options?.tx ?? this.prismaService;
     const id = place.getId().value;
     const currentVersion = place.getVersion().value;

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-place.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-place.repository.ts
@@ -15,16 +15,24 @@ import { ConcurrencyError } from '../../../../shared/errors';
 export class PrismaPlaceRepository implements PlaceRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async save(place: Place, tx?: PrismaTx): Promise<void> {
-    const prisma = tx ?? this.prismaService;
+  async save(
+    place: Place,
+    options?: { isNew?: boolean; tx?: PrismaTx },
+  ): Promise<void> {
+    const prisma = options?.tx ?? this.prismaService;
     const id = place.getId().value;
     const currentVersion = place.getVersion().value;
+    const isNew = options?.isNew ?? false;
 
     const record = await prisma.place.findUnique({
       where: { id },
     });
 
     if (!record) {
+      if (!isNew) {
+        throw new ConcurrencyError('Place', id);
+      }
+
       await prisma.place.create({
         data: {
           id: place.getId().value,

--- a/apps/api/src/modules/parking/infrastructure/persistence/prisma-place.repository.ts
+++ b/apps/api/src/modules/parking/infrastructure/persistence/prisma-place.repository.ts
@@ -46,6 +46,10 @@ export class PrismaPlaceRepository implements PlaceRepository {
       return;
     }
 
+    if (isNew) {
+      throw new ConcurrencyError('Place', id);
+    }
+
     try {
       await prisma.place.update({
         where: {

--- a/apps/api/src/shared/types.ts
+++ b/apps/api/src/shared/types.ts
@@ -1,0 +1,6 @@
+import { PrismaTx } from './prisma/types';
+
+export type RepositorySaveOptions = {
+  isNew?: boolean;
+  tx?: PrismaTx;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added handlers to track parking spot lifecycle events: created, updated, activated, and deactivated.

* **Refactor**
  * Repository save APIs unified to accept a generic options object (including an isNew flag), changing create vs concurrency behavior for persistence.

* **Tests**
  * Updated tests to assert save calls include the options object (isNew: true) when creating new entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->