### PR TITLE
101-admin---change-password-command

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -91,6 +91,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/apps/api/src/modules/admin-api/endpoints/auth/auth.controller.ts
+++ b/apps/api/src/modules/admin-api/endpoints/auth/auth.controller.ts
@@ -19,6 +19,7 @@ import { PublicApi } from '../../auth/decorators/public-api.decorator';
 import { LocalAuthGuard } from '../../auth/guards/local-auth.guard';
 import { RequestResetPasswordTokenDto } from './dto/request-reset-password-token.dto';
 import { ResetPasswordTokenDto } from './dto/reset-password-token.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 
 @ApiTags('Admin Auth')
 @Controller('admin/auth')
@@ -142,5 +143,24 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async resetPasswordToken(@Body() dto: ResetPasswordTokenDto) {
     await this.adminIamFacade.resetPassword(dto.token, dto.password);
+  }
+
+  @ApiBearerAuth('admin-auth')
+  @ApiOperation({ summary: 'Change password' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Password changed successfully',
+  })
+  @Post('change-password')
+  @HttpCode(HttpStatus.OK)
+  async changePassword(
+    @CurrentAdminUserId() adminUserId: string,
+    @Body() dto: ChangePasswordDto,
+  ) {
+    await this.adminIamFacade.changePassword(
+      adminUserId,
+      dto.existingPassword,
+      dto.newPassword,
+    );
   }
 }

--- a/apps/api/src/modules/admin-api/endpoints/auth/dto/change-password.dto.ts
+++ b/apps/api/src/modules/admin-api/endpoints/auth/dto/change-password.dto.ts
@@ -1,0 +1,25 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ChangePasswordDto {
+  @ApiProperty({
+    description: 'The existing password',
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsString()
+  readonly existingPassword: string;
+
+  @ApiProperty({
+    description: 'The new password',
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsString()
+  readonly newPassword: string;
+
+  constructor(existingPassword: string, newPassword: string) {
+    this.existingPassword = existingPassword;
+    this.newPassword = newPassword;
+  }
+}

--- a/apps/api/src/modules/admin-iam/application/admin-iam.facade.ts
+++ b/apps/api/src/modules/admin-iam/application/admin-iam.facade.ts
@@ -15,6 +15,7 @@ import { InviteAdminUserCommand } from './commands/invite-admin-user.command';
 import { GenerateResetPasswordTokenCommand } from './commands/generate-reset-password-token.command';
 import { ValidateUserQuery } from './queries/validate-user.query';
 import { GetAdminUserByIdQuery } from './queries/get-admin-user-by-id.query';
+import { ChangePasswordCommand } from './commands/change-password.command';
 import { AdminUserDetailsReadModel } from './query-handlers/read-models/admin-user-details.read-model';
 
 @Injectable()
@@ -108,5 +109,15 @@ export class AdminIamFacade {
       GetAdminUserByIdQuery,
       AdminUserDetailsReadModel
     >(query);
+  }
+
+  async changePassword(
+    adminUserId: string,
+    existingPassword: string,
+    newPassword: string,
+  ) {
+    return await this.commandBus.execute<ChangePasswordCommand, void>(
+      new ChangePasswordCommand(adminUserId, existingPassword, newPassword),
+    );
   }
 }

--- a/apps/api/src/modules/admin-iam/application/command-handlers/__tests/change-password.command-handler.spec.ts
+++ b/apps/api/src/modules/admin-iam/application/command-handlers/__tests/change-password.command-handler.spec.ts
@@ -7,11 +7,11 @@ import { ChangePasswordCommand } from '../../commands/change-password.command';
 import { PasswordService } from '../../ports/password.service';
 import { AdminUser } from '../../../domain/admin-user';
 import { AdminId } from '../../../domain/value-objects/admin-id';
-import { Email } from '../../../../../shared/value-objects/email';
+import { Email } from 'src/shared/value-objects/email';
 import { AdminDisplayName } from '../../../domain/value-objects/admin-display-name';
 import { AdminStatus } from '../../../domain/value-objects/admin-status';
-import { AggregateVersion } from '../../../../../shared/value-objects/aggregate-version';
-import { AppError } from '../../../../../shared/errors';
+import { AggregateVersion } from 'src/shared/value-objects/aggregate-version';
+import { AppError } from 'src/shared/errors';
 
 describe('ChangePasswordCommandHandler', () => {
   let handler: ChangePasswordCommandHandler;

--- a/apps/api/src/modules/admin-iam/application/command-handlers/__tests/change-password.command-handler.spec.ts
+++ b/apps/api/src/modules/admin-iam/application/command-handlers/__tests/change-password.command-handler.spec.ts
@@ -1,0 +1,162 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventPublisher } from '@nestjs/cqrs';
+import { randomUUID } from 'node:crypto';
+import { ChangePasswordCommandHandler } from '../change-password.command-handler';
+import { AdminUserRepository } from '../../ports/admin-user.repository';
+import { ChangePasswordCommand } from '../../commands/change-password.command';
+import { PasswordService } from '../../ports/password.service';
+import { AdminUser } from '../../../domain/admin-user';
+import { AdminId } from '../../../domain/value-objects/admin-id';
+import { Email } from '../../../../../shared/value-objects/email';
+import { AdminDisplayName } from '../../../domain/value-objects/admin-display-name';
+import { AdminStatus } from '../../../domain/value-objects/admin-status';
+import { AggregateVersion } from '../../../../../shared/value-objects/aggregate-version';
+import { AppError } from '../../../../../shared/errors';
+
+describe('ChangePasswordCommandHandler', () => {
+  let handler: ChangePasswordCommandHandler;
+  let adminUserRepository: jest.Mocked<AdminUserRepository>;
+  let eventPublisher: jest.Mocked<EventPublisher>;
+  let passwordService: jest.Mocked<PasswordService>;
+
+  beforeEach(async () => {
+    adminUserRepository = {
+      findById: jest.fn(),
+      save: jest.fn(),
+    } as unknown as jest.Mocked<AdminUserRepository>;
+
+    eventPublisher = {
+      mergeObjectContext: jest.fn(<T>(obj: T) => obj),
+    } as unknown as jest.Mocked<EventPublisher>;
+
+    passwordService = {
+      compare: jest.fn(),
+      create: jest.fn(),
+    } as unknown as jest.Mocked<PasswordService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChangePasswordCommandHandler,
+        {
+          provide: AdminUserRepository,
+          useValue: adminUserRepository,
+        },
+        {
+          provide: EventPublisher,
+          useValue: eventPublisher,
+        },
+        {
+          provide: PasswordService,
+          useValue: passwordService,
+        },
+      ],
+    }).compile();
+
+    handler = module.get<ChangePasswordCommandHandler>(
+      ChangePasswordCommandHandler,
+    );
+  });
+
+  it('should change password successfully', async () => {
+    // Given
+    const adminUserId = randomUUID();
+    const existingPassword = 'old-password';
+    const newPassword = 'new-password';
+    const oldHash = 'old-hash';
+    const newHash = 'new-hash';
+
+    const command = new ChangePasswordCommand(
+      adminUserId,
+      existingPassword,
+      newPassword,
+    );
+
+    const adminUser = AdminUser.reconstruct(
+      AdminId.fromString(adminUserId),
+      Email.fromString('test@example.com'),
+      false,
+      AdminDisplayName.fromString('Test User'),
+      AdminStatus.active(),
+      AggregateVersion.one(),
+      new Date(),
+      new Date(),
+      oldHash,
+    );
+
+    adminUserRepository.findById.mockResolvedValue(adminUser);
+    passwordService.compare.mockResolvedValue(true);
+    passwordService.create.mockResolvedValue(newHash);
+    const commitSpy = jest.spyOn(adminUser, 'commit');
+    const changePasswordSpy = jest.spyOn(adminUser, 'changePassword');
+
+    // When
+    await handler.execute(command);
+
+    // Then
+    expect(adminUserRepository.findById).toHaveBeenCalledWith(adminUserId);
+    expect(eventPublisher.mergeObjectContext).toHaveBeenCalledWith(adminUser);
+    expect(passwordService.compare).toHaveBeenCalledWith(
+      oldHash,
+      existingPassword,
+    );
+    expect(passwordService.create).toHaveBeenCalledWith(newPassword);
+    expect(changePasswordSpy).toHaveBeenCalledWith(newHash);
+    expect(adminUserRepository.save).toHaveBeenCalledWith(adminUser);
+    expect(commitSpy).toHaveBeenCalled();
+    expect(adminUser.getPasswordHash()).toBe(newHash);
+  });
+
+  it('should throw error if admin user not found', async () => {
+    // Given
+    const adminUserId = randomUUID();
+    const command = new ChangePasswordCommand(
+      adminUserId,
+      'old-password',
+      'new-password',
+    );
+
+    adminUserRepository.findById.mockResolvedValue(null);
+
+    // When & Then
+    await expect(handler.execute(command)).rejects.toThrow(
+      new AppError('ENTITY_NOT_FOUND', 'Admin user not found'),
+    );
+  });
+
+  it('should throw error if existing password is invalid', async () => {
+    // Given
+    const adminUserId = randomUUID();
+    const existingPassword = 'wrong-password';
+    const command = new ChangePasswordCommand(
+      adminUserId,
+      existingPassword,
+      'new-password',
+    );
+
+    const adminUser = AdminUser.reconstruct(
+      AdminId.fromString(adminUserId),
+      Email.fromString('test@example.com'),
+      false,
+      AdminDisplayName.fromString('Test User'),
+      AdminStatus.active(),
+      AggregateVersion.one(),
+      new Date(),
+      new Date(),
+      'old-hash',
+    );
+
+    adminUserRepository.findById.mockResolvedValue(adminUser);
+    passwordService.compare.mockResolvedValue(false);
+
+    // When & Then
+    await expect(handler.execute(command)).rejects.toThrow(
+      new AppError('VALIDATION_ERROR', 'Invalid existing password'),
+    );
+    expect(passwordService.compare).toHaveBeenCalledWith(
+      'old-hash',
+      existingPassword,
+    );
+    expect(passwordService.create).not.toHaveBeenCalled();
+    expect(adminUserRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/admin-iam/application/command-handlers/change-password.command-handler.ts
+++ b/apps/api/src/modules/admin-iam/application/command-handlers/change-password.command-handler.ts
@@ -1,0 +1,43 @@
+import { CommandHandler, EventPublisher, ICommandHandler } from '@nestjs/cqrs';
+import { ChangePasswordCommand } from '../commands/change-password.command';
+import { AdminUserRepository } from '../ports/admin-user.repository';
+import { AppError } from '../../../../shared/errors';
+import { PasswordService } from '../ports/password.service';
+
+@CommandHandler(ChangePasswordCommand)
+export class ChangePasswordCommandHandler implements ICommandHandler<
+  ChangePasswordCommand,
+  void
+> {
+  constructor(
+    private readonly adminUserRepository: AdminUserRepository,
+    private readonly eventPublisher: EventPublisher,
+    private readonly passwordService: PasswordService,
+  ) {}
+
+  async execute(command: ChangePasswordCommand): Promise<void> {
+    const { adminUserId, existingPassword, newPassword } = command;
+
+    const adminUser = await this.adminUserRepository.findById(adminUserId);
+
+    if (!adminUser) {
+      throw new AppError('ENTITY_NOT_FOUND', 'Admin user not found');
+    }
+
+    this.eventPublisher.mergeObjectContext(adminUser);
+
+    const isValid = await this.passwordService.compare(
+      adminUser.getPasswordHash() ?? '',
+      existingPassword,
+    );
+
+    if (!isValid) {
+      throw new AppError('VALIDATION_ERROR', 'Invalid existing password');
+    }
+
+    const newHash = await this.passwordService.create(newPassword);
+    adminUser.changePassword(newHash);
+    await this.adminUserRepository.save(adminUser);
+    adminUser.commit();
+  }
+}

--- a/apps/api/src/modules/admin-iam/application/command-handlers/change-password.command-handler.ts
+++ b/apps/api/src/modules/admin-iam/application/command-handlers/change-password.command-handler.ts
@@ -1,7 +1,7 @@
 import { CommandHandler, EventPublisher, ICommandHandler } from '@nestjs/cqrs';
 import { ChangePasswordCommand } from '../commands/change-password.command';
 import { AdminUserRepository } from '../ports/admin-user.repository';
-import { AppError } from '../../../../shared/errors';
+import { AppError } from 'src/shared/errors';
 import { PasswordService } from '../ports/password.service';
 
 @CommandHandler(ChangePasswordCommand)

--- a/apps/api/src/modules/admin-iam/application/command-handlers/index.ts
+++ b/apps/api/src/modules/admin-iam/application/command-handlers/index.ts
@@ -6,6 +6,7 @@ import { RequestResetPasswordCommandHandler } from './request-reset-password.com
 import { ResetPasswordCommandHandler } from './reset-password.command-handler';
 import { InviteAdminUserCommandHandler } from './invite-admin-user.command-handler';
 import { GenerateResetPasswordTokenCommandHandler } from './generate-reset-password-token.command-handler';
+import { ChangePasswordCommandHandler } from './change-password.command-handler';
 
 export const commandHandlers = [
   SignInCommandHandler,
@@ -16,4 +17,5 @@ export const commandHandlers = [
   ResetPasswordCommandHandler,
   InviteAdminUserCommandHandler,
   GenerateResetPasswordTokenCommandHandler,
+  ChangePasswordCommandHandler,
 ];

--- a/apps/api/src/modules/admin-iam/application/commands/change-password.command.ts
+++ b/apps/api/src/modules/admin-iam/application/commands/change-password.command.ts
@@ -1,0 +1,9 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class ChangePasswordCommand implements ICommand {
+  constructor(
+    public readonly adminUserId: string,
+    public readonly existingPassword: string,
+    public readonly newPassword: string,
+  ) {}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can change their password via a new authenticated endpoint; current password is validated before update.

* **Tests**
  * Added comprehensive tests covering successful password changes and error cases (user not found, incorrect current password).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->