### PR TITLE
feat: add password reset flow with request and set new password forms, and API integration

### DIFF
--- a/apps/admin-client/src/features/auth/api/index.ts
+++ b/apps/admin-client/src/features/auth/api/index.ts
@@ -2,6 +2,8 @@ import { createServerFn } from '@tanstack/react-start';
 import {
   changePasswordInputSchema,
   getMeResponseSchema,
+  requestResetPasswordInputSchema,
+  resetPasswordInputSchema,
   signInResponseSchema,
 } from '#/features/auth/schemas';
 import type { SignInSchema } from '#/features/auth/schemas';
@@ -131,6 +133,53 @@ export const changePassword = createServerFn()
   .inputValidator(changePasswordInputSchema)
   .handler(async ({ data }) => {
     const response = await authFetch(`${env.SERVER_URL}/auth/change-password`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+
+    await genericApiErrorHandler(response);
+  });
+
+/**
+ * A function used to initiate a password reset request for a user.
+ * This function validates the provided input data, sends a POST request to the server
+ * to request a reset password token, and processes the response.
+ * Specifically, it ensures errors are handled using a generic API error handler.
+ *
+ * The server URL endpoint for the request is defined by the application configuration.
+ *
+ * The input data for this function is validated against a predefined schema.
+ */
+export const requestResetPassword = createServerFn()
+  .inputValidator(requestResetPasswordInputSchema)
+  .handler(async ({ data }) => {
+    const response = await authFetch(
+      `${env.SERVER_URL}/auth/request-reset-password-token`,
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      },
+    );
+
+    await genericApiErrorHandler(response);
+  });
+
+/**
+ * Function to handle resetting user passwords through a server-side operation.
+ * This function uses an input validator to validate the input schema, then sends
+ * a POST request with the provided data to the server's reset-password endpoint.
+ * It also handles generic API errors that may occur during the operation.
+ *
+ * The `resetPassword` variable is initialized using a server function generator
+ * and incorporates the following steps:
+ * 1. Input validation using `resetPasswordInputSchema` to ensure required data is valid.
+ * 2. Sending a request to reset the password via the server's API.
+ * 3. Handling potential errors through a generic API error handler function.
+ */
+export const resetPassword = createServerFn()
+  .inputValidator(resetPasswordInputSchema)
+  .handler(async ({ data }) => {
+    const response = await authFetch(`${env.SERVER_URL}/auth/reset-password`, {
       method: 'POST',
       body: JSON.stringify(data),
     });

--- a/apps/admin-client/src/features/auth/api/index.ts
+++ b/apps/admin-client/src/features/auth/api/index.ts
@@ -153,10 +153,13 @@ export const changePassword = createServerFn()
 export const requestResetPassword = createServerFn()
   .inputValidator(requestResetPasswordInputSchema)
   .handler(async ({ data }) => {
-    const response = await authFetch(
+    const response = await fetch(
       `${env.SERVER_URL}/auth/request-reset-password-token`,
       {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify(data),
       },
     );
@@ -179,9 +182,12 @@ export const requestResetPassword = createServerFn()
 export const resetPassword = createServerFn()
   .inputValidator(resetPasswordInputSchema)
   .handler(async ({ data }) => {
-    const response = await authFetch(`${env.SERVER_URL}/auth/reset-password`, {
+    const response = await fetch(`${env.SERVER_URL}/auth/reset-password`, {
       method: 'POST',
       body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
 
     await genericApiErrorHandler(response);

--- a/apps/admin-client/src/features/auth/components/request-reset-password-form.tsx
+++ b/apps/admin-client/src/features/auth/components/request-reset-password-form.tsx
@@ -1,0 +1,114 @@
+import { Alert, AlertDescription, AlertTitle } from '#/components/ui/alert';
+import { Button } from '#/components/ui/button';
+import { Field, FieldError, FieldLabel } from '#/components/ui/field';
+import { Input } from '#/components/ui/input';
+import { Spinner } from '#/components/ui/spinner';
+import { requestResetPassword } from '#/features/auth/api';
+import { requestResetPasswordInputSchema } from '#/features/auth/schemas';
+import { useForm } from '@tanstack/react-form';
+import { Link } from '@tanstack/react-router';
+import { useServerFn } from '@tanstack/react-start';
+import { Mail } from 'lucide-react';
+import { useState } from 'react';
+
+export function RequestResetPasswordForm() {
+  const [hasError, setHasError] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isFormSubmitting, setIsFormSubmitting] = useState(false);
+
+  const requestResetPasswordFn = useServerFn(requestResetPassword);
+
+  const form = useForm({
+    defaultValues: {
+      email: '',
+    },
+    validators: {
+      onSubmit: requestResetPasswordInputSchema,
+    },
+    onSubmit: async ({ value }) => {
+      setHasError(false);
+      setIsSubmitted(false);
+      setIsFormSubmitting(true);
+
+      try {
+        await requestResetPasswordFn({
+          data: value,
+        });
+        setIsSubmitted(true);
+      } catch {
+        setHasError(true);
+      } finally {
+        setIsFormSubmitting(false);
+      }
+    },
+  });
+
+  return (
+    <form
+      className="space-y-5"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        await form.handleSubmit();
+      }}
+    >
+      {hasError && (
+        <Alert variant="destructive">
+          <AlertTitle>Błąd podczas resetowania hasła</AlertTitle>
+          <AlertDescription>
+            Nie udało się wysłać linku resetującego. Spróbuj ponownie.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {isSubmitted && (
+        <Alert>
+          <AlertTitle>Sprawdź skrzynkę email</AlertTitle>
+          <AlertDescription>
+            Jeśli konto istnieje, wyślemy link do zresetowania hasła.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <form.Field
+        name="email"
+        children={(field) => {
+          const isInvalid =
+            field.state.meta.isTouched && !field.state.meta.isValid;
+
+          return (
+            <Field data-invalid={isInvalid}>
+              <FieldLabel htmlFor={field.name}>Adres email</FieldLabel>
+              <div className="relative">
+                <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  id={field.name}
+                  name={field.name}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  autoComplete="email"
+                  aria-invalid={isInvalid}
+                  className="pl-9"
+                />
+              </div>
+              {isInvalid && <FieldError errors={field.state.meta.errors} />}
+            </Field>
+          );
+        }}
+      />
+
+      <Button
+        type="submit"
+        className="h-11 w-full"
+        disabled={isFormSubmitting || form.state.isSubmitting}
+      >
+        {(isFormSubmitting || form.state.isSubmitting) && <Spinner />}
+        Wyślij link resetujący
+      </Button>
+
+      <Button asChild type="button" variant="link" className="h-auto w-full">
+        <Link to="/auth/sign-in">Wróć do logowania</Link>
+      </Button>
+    </form>
+  );
+}

--- a/apps/admin-client/src/features/auth/components/reset-password-form.tsx
+++ b/apps/admin-client/src/features/auth/components/reset-password-form.tsx
@@ -1,0 +1,160 @@
+import { Alert, AlertDescription, AlertTitle } from '#/components/ui/alert';
+import { Button } from '#/components/ui/button';
+import { Field, FieldError, FieldLabel } from '#/components/ui/field';
+import { Input } from '#/components/ui/input';
+import { Spinner } from '#/components/ui/spinner';
+import { resetPassword } from '#/features/auth/api';
+import { resetPasswordFormSchema } from '#/features/auth/schemas';
+import { useForm } from '@tanstack/react-form';
+import { Link } from '@tanstack/react-router';
+import { useServerFn } from '@tanstack/react-start';
+import { CheckCircle2, LockKeyhole } from 'lucide-react';
+import { useState } from 'react';
+
+type ResetPasswordFormProps = Readonly<{
+  token: string;
+}>;
+
+export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const resetPasswordFn = useServerFn(resetPassword);
+
+  const form = useForm({
+    defaultValues: {
+      token,
+      password: '',
+      confirmPassword: '',
+    },
+    validators: {
+      onSubmit: resetPasswordFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      setErrorMessage(null);
+      setIsSubmitted(false);
+
+      try {
+        await resetPasswordFn({
+          data: {
+            token: value.token,
+            password: value.password,
+          },
+        });
+        form.reset();
+        setIsSubmitted(true);
+      } catch (error) {
+        if (error instanceof Error) {
+          setErrorMessage(error.message);
+        } else {
+          setErrorMessage('Nie udało się ustawić nowego hasła.');
+        }
+      }
+    },
+  });
+
+  if (isSubmitted) {
+    return (
+      <div className="space-y-5">
+        <Alert>
+          <CheckCircle2 className="size-4" />
+          <AlertTitle>Hasło zostało zmienione</AlertTitle>
+          <AlertDescription>
+            Możesz teraz zalogować się używając nowego hasła.
+          </AlertDescription>
+        </Alert>
+        <Button asChild className="h-11 w-full">
+          <Link to="/auth/sign-in">Przejdź do logowania</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="space-y-5"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        await form.handleSubmit();
+      }}
+    >
+      {errorMessage && (
+        <Alert variant="destructive">
+          <AlertTitle>Błąd podczas zmiany hasła</AlertTitle>
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
+      )}
+
+      <form.Field
+        name="password"
+        children={(field) => {
+          const isInvalid =
+            field.state.meta.isTouched && !field.state.meta.isValid;
+
+          return (
+            <Field data-invalid={isInvalid}>
+              <FieldLabel htmlFor={field.name}>Nowe hasło</FieldLabel>
+              <div className="relative">
+                <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  id={field.name}
+                  name={field.name}
+                  type="password"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  autoComplete="new-password"
+                  aria-invalid={isInvalid}
+                  className="pl-9"
+                />
+              </div>
+              {isInvalid && <FieldError errors={field.state.meta.errors} />}
+            </Field>
+          );
+        }}
+      />
+
+      <form.Field
+        name="confirmPassword"
+        children={(field) => {
+          const isInvalid =
+            field.state.meta.isTouched && !field.state.meta.isValid;
+
+          return (
+            <Field data-invalid={isInvalid}>
+              <FieldLabel htmlFor={field.name}>Powtórz nowe hasło</FieldLabel>
+              <div className="relative">
+                <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  id={field.name}
+                  name={field.name}
+                  type="password"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  autoComplete="new-password"
+                  aria-invalid={isInvalid}
+                  className="pl-9"
+                />
+              </div>
+              {isInvalid && <FieldError errors={field.state.meta.errors} />}
+            </Field>
+          );
+        }}
+      />
+
+      <Button
+        type="submit"
+        className="h-11 w-full"
+        disabled={form.state.isSubmitting}
+      >
+        {form.state.isSubmitting && <Spinner />}
+        Ustaw nowe hasło
+      </Button>
+
+      <Button asChild type="button" variant="link" className="h-auto w-full">
+        <Link to="/auth/sign-in">Wróć do logowania</Link>
+      </Button>
+    </form>
+  );
+}

--- a/apps/admin-client/src/features/auth/components/sign-in-form.tsx
+++ b/apps/admin-client/src/features/auth/components/sign-in-form.tsx
@@ -8,7 +8,7 @@ import { useServerFn } from '@tanstack/react-start';
 import { signIn } from '#/features/auth/api';
 import { useForm } from '@tanstack/react-form';
 import { signInSchema } from '#/features/auth/schemas';
-import { isRedirect } from '@tanstack/react-router';
+import { Link, isRedirect } from '@tanstack/react-router';
 import { LockKeyhole, Mail } from 'lucide-react';
 
 export function SignInForm() {
@@ -116,6 +116,12 @@ export function SignInForm() {
           );
         }}
       />
+
+      <div className="flex justify-end">
+        <Button asChild type="button" variant="link" className="h-auto px-0">
+          <Link to="/auth/reset-password">Nie pamiętasz hasła?</Link>
+        </Button>
+      </div>
 
       <Button
         type={'submit'}

--- a/apps/admin-client/src/features/auth/schemas/index.ts
+++ b/apps/admin-client/src/features/auth/schemas/index.ts
@@ -38,10 +38,6 @@ export const changePasswordInputSchema = z.object({
     .min(8, { message: 'New password must be at least 8 characters' }),
 });
 
-export type ChangePasswordInputSchema = z.infer<
-  typeof changePasswordInputSchema
->;
-
 export const changePasswordFormSchema = changePasswordInputSchema
   .extend({
     confirmNewPassword: z
@@ -51,4 +47,24 @@ export const changePasswordFormSchema = changePasswordInputSchema
   .refine((data) => data.newPassword === data.confirmNewPassword, {
     message: 'Passwords do not match',
     path: ['confirmNewPassword'],
+  });
+
+export const requestResetPasswordInputSchema = z.object({ email: z.email() });
+
+export const resetPasswordInputSchema = z.object({
+  token: z.uuid(),
+  password: z
+    .string()
+    .min(8, { message: 'Password must be at least 8 characters' }),
+});
+
+export const resetPasswordFormSchema = resetPasswordInputSchema
+  .extend({
+    confirmPassword: z
+      .string()
+      .min(1, { message: 'Please confirm the new password' }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
   });

--- a/apps/admin-client/src/routeTree.gen.ts
+++ b/apps/admin-client/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as AuthRouteRouteImport } from './routes/auth/route'
 import { Route as ProtectedRouteRouteImport } from './routes/_protected/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthSignInIndexRouteImport } from './routes/auth/sign-in/index'
+import { Route as AuthResetPasswordIndexRouteImport } from './routes/auth/reset-password/index'
 import { Route as ProtectedAppIndexRouteImport } from './routes/_protected/app/index'
 import { Route as ProtectedAppParkingsIndexRouteImport } from './routes/_protected/app/parkings/index'
 import { Route as ProtectedAppOrganizationsIndexRouteImport } from './routes/_protected/app/organizations/index'
@@ -41,6 +42,11 @@ const IndexRoute = IndexRouteImport.update({
 const AuthSignInIndexRoute = AuthSignInIndexRouteImport.update({
   id: '/sign-in/',
   path: '/sign-in/',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthResetPasswordIndexRoute = AuthResetPasswordIndexRouteImport.update({
+  id: '/reset-password/',
+  path: '/reset-password/',
   getParentRoute: () => AuthRouteRoute,
 } as any)
 const ProtectedAppIndexRoute = ProtectedAppIndexRouteImport.update({
@@ -107,6 +113,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth': typeof AuthRouteRouteWithChildren
   '/app/': typeof ProtectedAppIndexRoute
+  '/auth/reset-password/': typeof AuthResetPasswordIndexRoute
   '/auth/sign-in/': typeof AuthSignInIndexRoute
   '/app/organizations/$organizationId': typeof ProtectedAppOrganizationsOrganizationIdRoute
   '/app/parkings/$parkingId': typeof ProtectedAppParkingsParkingIdRoute
@@ -122,6 +129,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRouteRouteWithChildren
   '/app': typeof ProtectedAppIndexRoute
+  '/auth/reset-password': typeof AuthResetPasswordIndexRoute
   '/auth/sign-in': typeof AuthSignInIndexRoute
   '/app/organizations/$organizationId': typeof ProtectedAppOrganizationsOrganizationIdRoute
   '/app/parkings/$parkingId': typeof ProtectedAppParkingsParkingIdRoute
@@ -139,6 +147,7 @@ export interface FileRoutesById {
   '/_protected': typeof ProtectedRouteRouteWithChildren
   '/auth': typeof AuthRouteRouteWithChildren
   '/_protected/app/': typeof ProtectedAppIndexRoute
+  '/auth/reset-password/': typeof AuthResetPasswordIndexRoute
   '/auth/sign-in/': typeof AuthSignInIndexRoute
   '/_protected/app/organizations/$organizationId': typeof ProtectedAppOrganizationsOrganizationIdRoute
   '/_protected/app/parkings/$parkingId': typeof ProtectedAppParkingsParkingIdRoute
@@ -156,6 +165,7 @@ export interface FileRouteTypes {
     | '/'
     | '/auth'
     | '/app/'
+    | '/auth/reset-password/'
     | '/auth/sign-in/'
     | '/app/organizations/$organizationId'
     | '/app/parkings/$parkingId'
@@ -171,6 +181,7 @@ export interface FileRouteTypes {
     | '/'
     | '/auth'
     | '/app'
+    | '/auth/reset-password'
     | '/auth/sign-in'
     | '/app/organizations/$organizationId'
     | '/app/parkings/$parkingId'
@@ -187,6 +198,7 @@ export interface FileRouteTypes {
     | '/_protected'
     | '/auth'
     | '/_protected/app/'
+    | '/auth/reset-password/'
     | '/auth/sign-in/'
     | '/_protected/app/organizations/$organizationId'
     | '/_protected/app/parkings/$parkingId'
@@ -233,6 +245,13 @@ declare module '@tanstack/react-router' {
       path: '/sign-in'
       fullPath: '/auth/sign-in/'
       preLoaderRoute: typeof AuthSignInIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/auth/reset-password/': {
+      id: '/auth/reset-password/'
+      path: '/reset-password'
+      fullPath: '/auth/reset-password/'
+      preLoaderRoute: typeof AuthResetPasswordIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_protected/app/': {
@@ -343,10 +362,12 @@ const ProtectedRouteRouteWithChildren = ProtectedRouteRoute._addFileChildren(
 )
 
 interface AuthRouteRouteChildren {
+  AuthResetPasswordIndexRoute: typeof AuthResetPasswordIndexRoute
   AuthSignInIndexRoute: typeof AuthSignInIndexRoute
 }
 
 const AuthRouteRouteChildren: AuthRouteRouteChildren = {
+  AuthResetPasswordIndexRoute: AuthResetPasswordIndexRoute,
   AuthSignInIndexRoute: AuthSignInIndexRoute,
 }
 

--- a/apps/admin-client/src/routes/auth/reset-password/index.tsx
+++ b/apps/admin-client/src/routes/auth/reset-password/index.tsx
@@ -1,0 +1,79 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '#/components/ui/card.tsx';
+import { Alert, AlertDescription, AlertTitle } from '#/components/ui/alert';
+import { RequestResetPasswordForm } from '#/features/auth/components/request-reset-password-form.tsx';
+import { ResetPasswordForm } from '#/features/auth/components/reset-password-form.tsx';
+import { Button } from '#/components/ui/button';
+import { ParkingCircle } from 'lucide-react';
+import { z } from 'zod';
+
+const resetPasswordSearchSchema = z.object({
+  token: z.string().optional(),
+});
+
+export const Route = createFileRoute('/auth/reset-password/')({
+  validateSearch: resetPasswordSearchSchema,
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { token } = Route.useSearch();
+  const isResetMode = Boolean(token);
+  const isValidToken = token ? z.uuid().safeParse(token).success : false;
+
+  return (
+    <div className="flex min-h-svh items-center justify-center px-4 py-10">
+      <div className="w-full max-w-[460px]">
+        <div className="mb-6 flex items-center justify-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-md shadow-primary/20">
+            <ParkingCircle className="size-6" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold">Parking Platform</p>
+            <p className="text-xs text-muted-foreground">Admin Console</p>
+          </div>
+        </div>
+        <Card className="shadow-[var(--elevated-shadow)]">
+          <CardHeader>
+            <CardTitle className="text-2xl">Reset hasła</CardTitle>
+            <CardDescription>
+              {isResetMode
+                ? 'Wpisz nowe hasło dla swojego konta.'
+                : 'Podaj adres email, a wyślemy link do zresetowania hasła.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isResetMode ? (
+              isValidToken ? (
+                <ResetPasswordForm token={token} />
+              ) : (
+                <div className="space-y-5">
+                  <Alert variant="destructive">
+                    <AlertTitle>Nieprawidłowy link resetujący</AlertTitle>
+                    <AlertDescription>
+                      Link do resetowania hasła jest niepoprawny. Poproś o nowy
+                      link i spróbuj ponownie.
+                    </AlertDescription>
+                  </Alert>
+                  <Button asChild className="h-11 w-full">
+                    <Link to="/auth/reset-password">
+                      Wyślij nowy link resetujący
+                    </Link>
+                  </Button>
+                </div>
+              )
+            ) : (
+              <RequestResetPasswordForm />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/api/src/modules/admin-iam/application/command-handlers/__tests/request-reset-password.command-handler.spec.ts
+++ b/apps/api/src/modules/admin-iam/application/command-handlers/__tests/request-reset-password.command-handler.spec.ts
@@ -77,7 +77,7 @@ describe('RequestResetPasswordCommandHandler', () => {
     );
     expect(outboxService.enqueue).toHaveBeenCalledWith(
       expect.any(IntegrationEvent),
-      { deduplicate: true },
+      { deduplicate: false },
       'mock-prisma-tx',
     );
     const enqueuedEvent = outboxService.enqueue.mock.calls[0][0];

--- a/apps/api/src/modules/admin-iam/application/command-handlers/request-reset-password.command-handler.ts
+++ b/apps/api/src/modules/admin-iam/application/command-handlers/request-reset-password.command-handler.ts
@@ -45,7 +45,7 @@ export class RequestResetPasswordCommandHandler implements ICommandHandler<
         'AdminUser',
         adminUser.getId().value,
       );
-      await this.outboxService.enqueue(event, { deduplicate: true }, prisma);
+      await this.outboxService.enqueue(event, { deduplicate: false }, prisma);
     });
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can request a password reset via email and complete reset using a tokenized link.
  * “Forgot password?” link added to sign-in; dedicated request and reset pages/forms with inline validation, submission spinners, and clear success/error messages.

* **Bug Fixes**
  * Reset requests are no longer deduplicated server-side, allowing repeated reset emails when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spectreitcom/parking-platform/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->