### PR TITLE
feat: add separate Swagger documentation for admin and app clients

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,8 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { AdminApiModule } from 'src/bff/admin-api/admin-api.module';
+import { ApiModule } from 'src/bff/api/api.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -34,8 +36,23 @@ async function bootstrap() {
         description: 'Enter JWT token',
         in: 'header',
       },
-      'admin-auth',
+      'auth',
     )
+    .build();
+
+  const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig, {
+    include: [ApiModule],
+  });
+
+  SwaggerModule.setup('docs/app', app, swaggerDocument, {
+    useGlobalPrefix: true,
+    jsonDocumentUrl: '/docs/app/json',
+  });
+
+  const adminSwaggerConfig = new DocumentBuilder()
+    .setTitle('Parking Platform API - Admin Client')
+    .setDescription('API documentation for Admin Client')
+    .setVersion('1.0.0')
     .addBearerAuth(
       {
         type: 'http',
@@ -45,14 +62,21 @@ async function bootstrap() {
         description: 'Enter JWT token',
         in: 'header',
       },
-      'auth',
+      'admin-auth',
     )
     .build();
-  const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
 
-  SwaggerModule.setup('docs', app, swaggerDocument, {
+  const adminSwaggerDocument = SwaggerModule.createDocument(
+    app,
+    adminSwaggerConfig,
+    {
+      include: [AdminApiModule],
+    },
+  );
+
+  SwaggerModule.setup('docs/admin', app, adminSwaggerDocument, {
     useGlobalPrefix: true,
-    jsonDocumentUrl: '/docs-json',
+    jsonDocumentUrl: '/docs/admin/json',
   });
 
   await app.listen(process.env.PORT ?? 3003);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -22,62 +22,64 @@ async function bootstrap() {
     }),
   );
 
-  // Swagger setup
-  const swaggerConfig = new DocumentBuilder()
-    .setTitle('Parking Platform API')
-    .setDescription('API documentation for Parking Platform')
-    .setVersion('1.0.0')
-    .addBearerAuth(
+  if (process.env.NODE_ENV === 'development') {
+    // Swagger setup
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('Parking Platform API')
+      .setDescription('API documentation for Parking Platform')
+      .setVersion('1.0.0')
+      .addBearerAuth(
+        {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          name: 'JWT',
+          description: 'Enter JWT token',
+          in: 'header',
+        },
+        'auth',
+      )
+      .build();
+
+    const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig, {
+      include: [ApiModule],
+    });
+
+    SwaggerModule.setup('docs/app', app, swaggerDocument, {
+      useGlobalPrefix: true,
+      jsonDocumentUrl: '/docs/app/json',
+    });
+
+    const adminSwaggerConfig = new DocumentBuilder()
+      .setTitle('Parking Platform API - Admin Client')
+      .setDescription('API documentation for Admin Client')
+      .setVersion('1.0.0')
+      .addBearerAuth(
+        {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          name: 'JWT',
+          description: 'Enter JWT token',
+          in: 'header',
+        },
+        'admin-auth',
+      )
+      .build();
+
+    const adminSwaggerDocument = SwaggerModule.createDocument(
+      app,
+      adminSwaggerConfig,
       {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'JWT',
-        description: 'Enter JWT token',
-        in: 'header',
+        include: [AdminApiModule],
       },
-      'auth',
-    )
-    .build();
+    );
 
-  const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig, {
-    include: [ApiModule],
-  });
-
-  SwaggerModule.setup('docs/app', app, swaggerDocument, {
-    useGlobalPrefix: true,
-    jsonDocumentUrl: '/docs/app/json',
-  });
-
-  const adminSwaggerConfig = new DocumentBuilder()
-    .setTitle('Parking Platform API - Admin Client')
-    .setDescription('API documentation for Admin Client')
-    .setVersion('1.0.0')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'JWT',
-        description: 'Enter JWT token',
-        in: 'header',
-      },
-      'admin-auth',
-    )
-    .build();
-
-  const adminSwaggerDocument = SwaggerModule.createDocument(
-    app,
-    adminSwaggerConfig,
-    {
-      include: [AdminApiModule],
-    },
-  );
-
-  SwaggerModule.setup('docs/admin', app, adminSwaggerDocument, {
-    useGlobalPrefix: true,
-    jsonDocumentUrl: '/docs/admin/json',
-  });
+    SwaggerModule.setup('docs/admin', app, adminSwaggerDocument, {
+      useGlobalPrefix: true,
+      jsonDocumentUrl: '/docs/admin/json',
+    });
+  }
 
   await app.listen(process.env.PORT ?? 3003);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API documentation is split into separate Public and Admin sections: Public docs at /docs/app (JSON at /docs/app/json) and Admin docs at /docs/admin (JSON at /docs/admin/json).
  * Documentation is now served only in development environments (enabled when NODE_ENV is development).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spectreitcom/parking-platform/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->