### PR TITLE
refactor: simplify parking list retrieval by moving `organizationId` to query params

### DIFF
--- a/apps/api/src/bff/manager-api/endpoints/parkings/dto/get-parkings-list-query-params.dto.ts
+++ b/apps/api/src/bff/manager-api/endpoints/parkings/dto/get-parkings-list-query-params.dto.ts
@@ -1,4 +1,11 @@
-import { IsInt, Max, IsOptional, Min } from 'class-validator';
+import {
+  IsInt,
+  Max,
+  IsOptional,
+  Min,
+  IsNotEmpty,
+  IsUUID,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from 'src/shared/constants';
@@ -27,8 +34,17 @@ export class GetParkingFeaturesListQueryParamsDto {
   @Max(MAX_PAGE_SIZE)
   readonly limit?: number;
 
-  constructor(page?: number, limit?: number) {
+  @ApiProperty({
+    description: 'The organization ID',
+    format: 'uuid',
+  })
+  @IsNotEmpty()
+  @IsUUID()
+  readonly organizationId: string;
+
+  constructor(organizationId: string, page?: number, limit?: number) {
     this.page = page;
     this.limit = limit;
+    this.organizationId = organizationId;
   }
 }

--- a/apps/api/src/bff/manager-api/endpoints/parkings/handlers/get-parkings-list.handler.ts
+++ b/apps/api/src/bff/manager-api/endpoints/parkings/handlers/get-parkings-list.handler.ts
@@ -12,14 +12,13 @@ export class GetParkingsListHandler implements IControllerHandler {
 
   async handle(
     queryParams: GetParkingFeaturesListQueryParamsDto,
-    organizationId: string,
     managerUser: RequestUser,
   ) {
     const organizationIds = managerUser.organizations.map(
       (organization) => organization.organizationId,
     );
 
-    if (!organizationIds.includes(organizationId)) {
+    if (!organizationIds.includes(queryParams.organizationId)) {
       throw new ForbiddenException(
         'You are not authorized to access this resource.',
       );
@@ -27,7 +26,7 @@ export class GetParkingsListHandler implements IControllerHandler {
 
     const parkings =
       await this.parkingFacade.getParkingsByOrganizationAndOrganizationUserForManager(
-        organizationId,
+        queryParams.organizationId,
         queryParams.page ?? 1,
         queryParams.limit ?? DEFAULT_PAGE_SIZE,
       );
@@ -42,7 +41,7 @@ export class GetParkingsListHandler implements IControllerHandler {
 
     const total =
       await this.parkingFacade.getParkingsByOrganizationAndOrganizationUserForManagerTotal(
-        organizationId,
+        queryParams.organizationId,
       );
 
     const data: (Omit<(typeof parkings)[number], 'placeId'> & {

--- a/apps/api/src/bff/manager-api/endpoints/parkings/parkings.controller.ts
+++ b/apps/api/src/bff/manager-api/endpoints/parkings/parkings.controller.ts
@@ -99,17 +99,12 @@ export class ParkingsController {
   @ApiUnauthorizedResponse({
     description: 'Unauthorized',
   })
-  @Get(':organizationId')
+  @Get()
   async getParkingsList(
     @Query() queryParams: GetParkingFeaturesListQueryParamsDto,
-    @Param('organizationId', new ParseUUIDPipe()) organizationId: string,
     @CurrentManagerUser() managerUser: RequestUser,
   ) {
-    return await this.getParkingsListHandler.handle(
-      queryParams,
-      organizationId,
-      managerUser,
-    );
+    return await this.getParkingsListHandler.handle(queryParams, managerUser);
   }
 
   @ApiOperation({ summary: 'Get parking details' })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated parking list API endpoint to accept organization ID as a query parameter instead of a URL path parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->