### PR TITLE
feat: add add-parking-spot modal with feature selection, server integration, and utility refactor

### DIFF
--- a/apps/admin-client/package.json
+++ b/apps/admin-client/package.json
@@ -15,6 +15,7 @@
     "check": "prettier --write . && eslint --fix"
   },
   "dependencies": {
+    "@repo/frontend-utils": "^1.0.0",
     "@t3-oss/env-core": "^0.13.11",
     "@tailwindcss/vite": "^4.3.1",
     "@tanstack/react-devtools": "^0.10.5",

--- a/apps/admin-client/src/features/admins/api/index.ts
+++ b/apps/admin-client/src/features/admins/api/index.ts
@@ -6,7 +6,7 @@ import {
 import type { AdminListInputSchema } from '#/features/admins/schemas';
 import { authFetch, genericApiErrorHandler } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
-import { createSearchParams } from '#/lib/utils.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getAdminsList = createServerFn()
   .validator((input: AdminListInputSchema) => {

--- a/apps/admin-client/src/features/organization-users/api/index.ts
+++ b/apps/admin-client/src/features/organization-users/api/index.ts
@@ -7,7 +7,6 @@ import {
   organizationUsersListInputSchema,
   resendInvitationForOrganizationUserInputSchema,
 } from '#/features/organization-users/schemas';
-import { createSearchParams } from '#/lib/utils.ts';
 import {
   authFetch,
   defaultServerError,
@@ -15,6 +14,7 @@ import {
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
 import { genericResponseSchema } from '#/lib/schemas.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getOrganizationUsers = createServerFn()
   .validator(organizationUsersListInputSchema)

--- a/apps/admin-client/src/features/organizations/api/index.ts
+++ b/apps/admin-client/src/features/organizations/api/index.ts
@@ -11,7 +11,6 @@ import {
   searchOrganizationUsersInputSchema,
   updateOrganizationInputSchema,
 } from '#/features/organizations/schemas';
-import { createSearchParams } from '#/lib/utils.ts';
 import {
   authFetch,
   defaultServerError,
@@ -19,6 +18,7 @@ import {
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
 import { genericResponseSchema } from '#/lib/schemas.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getOrganizationsList = createServerFn()
   .validator(organizationsListInputSchema)

--- a/apps/admin-client/src/features/parkings/api/parking-features.ts
+++ b/apps/admin-client/src/features/parkings/api/parking-features.ts
@@ -9,13 +9,13 @@ import {
   parkingListBaseInputSchema,
   updateParkingFeatureInputSchema,
 } from '#/features/parkings/schemas';
-import { createSearchParams } from '#/lib/utils.ts';
 import {
   authFetch,
   defaultServerError,
   genericApiErrorHandler,
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getParkingFeatures = createServerFn()
   .validator(parkingListBaseInputSchema)

--- a/apps/admin-client/src/features/parkings/api/parking.ts
+++ b/apps/admin-client/src/features/parkings/api/parking.ts
@@ -8,7 +8,6 @@ import {
   parkingListSchema,
   updateParkingInputSchema,
 } from '#/features/parkings/schemas';
-import { createSearchParams } from '#/lib/utils.ts';
 import {
   authFetch,
   defaultServerError,
@@ -16,6 +15,7 @@ import {
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
 import { genericResponseSchema } from '#/lib/schemas.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getParkingList = createServerFn()
   .validator(parkingListBaseInputSchema)

--- a/apps/admin-client/src/features/parkings/api/place-types.ts
+++ b/apps/admin-client/src/features/parkings/api/place-types.ts
@@ -7,13 +7,13 @@ import {
   placeTypesListSchema,
   updatePlaceTypeInputSchema,
 } from '#/features/parkings/schemas';
-import { createSearchParams } from '#/lib/utils.ts';
 import {
   authFetch,
   defaultServerError,
   genericApiErrorHandler,
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getPlaceTypes = createServerFn()
   .validator(parkingListBaseInputSchema)

--- a/apps/admin-client/src/features/parkings/api/places.ts
+++ b/apps/admin-client/src/features/parkings/api/places.ts
@@ -8,7 +8,6 @@ import {
   placesListSchema,
   updatePlaceInputSchema,
 } from '#/features/parkings/schemas';
-import { createSearchParams } from '#/lib/utils.ts';
 import {
   authFetch,
   defaultServerError,
@@ -16,6 +15,7 @@ import {
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
 import { genericResponseSchema } from '#/lib/schemas.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getPlacesList = createServerFn()
   .validator(placesListBaseInputSchema)

--- a/apps/admin-client/src/lib/utils.ts
+++ b/apps/admin-client/src/lib/utils.ts
@@ -5,17 +5,3 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-export function createSearchParams<T extends Record<string, string | number>>(
-  data: T,
-): URLSearchParams {
-  const searchParams = new URLSearchParams();
-
-  for (const [key, value] of Object.entries(data)) {
-    if (value) {
-      searchParams.append(key, value.toString());
-    }
-  }
-
-  return searchParams;
-}

--- a/apps/api/src/bff/manager-api/endpoints/parking-features/dto/get-parking-features-list-query-params.dto.ts
+++ b/apps/api/src/bff/manager-api/endpoints/parking-features/dto/get-parking-features-list-query-params.dto.ts
@@ -8,8 +8,16 @@ import {
   MaxLength,
   Min,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from 'src/shared/constants';
+
+function isLevelValueString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isLevelValueArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isLevelValueString);
+}
 
 export class GetParkingFeaturesListQueryParamsDto {
   @ApiProperty({
@@ -44,8 +52,18 @@ export class GetParkingFeaturesListQueryParamsDto {
   @MaxLength(255)
   readonly search?: string;
 
+  @ApiProperty({
+    description:
+      'The levels to filter by. Allowed values are PARKING, PARKING_SPOT',
+    required: false,
+  })
   @IsOptional()
   @IsArray()
+  @Transform(({ value }) => {
+    if (isLevelValueString(value)) return [value];
+    else if (isLevelValueArray(value)) return value;
+    else return undefined;
+  })
   @IsIn(['PARKING', 'PARKING_SPOT'], { each: true })
   readonly levels?: string[];
 

--- a/apps/api/src/bff/manager-api/endpoints/parking-spots/handlers/get-parking-spots.handler.ts
+++ b/apps/api/src/bff/manager-api/endpoints/parking-spots/handlers/get-parking-spots.handler.ts
@@ -55,15 +55,16 @@ export class GetParkingSpotsHandler implements IControllerHandler {
     for (const parkingSpot of parkingSpots) {
       const { pricePLN } = parkingSpot;
 
+      const parkingSpotFeatures = parkingFeatures.filter((feature) =>
+        parkingSpot.parkingSpotFeatureIds.includes(feature.id),
+      );
+
       data.push({
         id: parkingSpot.id,
         active: parkingSpot.active,
         version: parkingSpot.version,
         price: pricePLN,
-        parkingSpotFeatures: parkingFeatures.map((feature) => ({
-          id: feature.id,
-          name: feature.name,
-        })),
+        parkingSpotFeatures,
       });
     }
 

--- a/apps/api/src/modules/parking/application/query-handlers/get-parking-features-list.query-handler.ts
+++ b/apps/api/src/modules/parking/application/query-handlers/get-parking-features-list.query-handler.ts
@@ -9,7 +9,7 @@ export const getParkingFeaturesListQueryWhere: (
   levels?: string[],
 ) => Prisma.ParkingFeatureReadWhereInput = (search, levels) => ({
   name: search ? { contains: search, mode: 'insensitive' } : undefined,
-  level: levels ? { in: levels } : undefined,
+  levels: levels && levels.length > 0 ? { hasSome: levels } : undefined,
 });
 
 @QueryHandler(GetParkingFeaturesListQuery)

--- a/apps/manager-client/package.json
+++ b/apps/manager-client/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
+    "@repo/frontend-utils": "^1.0.0",
     "@t3-oss/env-core": "^0.13.11",
     "@tailwindcss/vite": "^4.3.1",
     "@tanstack/match-sorter-utils": "latest",

--- a/apps/manager-client/src/features/parking-features/api/index.ts
+++ b/apps/manager-client/src/features/parking-features/api/index.ts
@@ -1,8 +1,8 @@
 import { createServerFn } from '@tanstack/react-start';
 import {
-  getParkingSpotsByParkingIdInputSchema,
-  parkingSpotListSchema,
-} from '#/features/parkings/schemas';
+  parkingFeatureListSchema,
+  parkingFeaturesListInputSchema,
+} from '#/features/parking-features/schemas';
 import {
   authFetch,
   defaultServerError,
@@ -11,25 +11,26 @@ import {
 import { env } from '#/env.ts';
 import { createSearchParams } from '@repo/frontend-utils';
 
-export const getParkingSpotsByParkingId = createServerFn()
-  .validator(getParkingSpotsByParkingIdInputSchema)
+export const getParkingFeatures = createServerFn()
+  .validator(parkingFeaturesListInputSchema)
   .handler(async ({ data }) => {
     const searchParams = createSearchParams({
-      ...data,
+      page: data.page,
+      limit: data.limit,
+      search: data.search ?? '',
+      levels: data.levels ?? [],
     });
 
     const response = await authFetch(
-      `${env.SERVER_URL}/parking-spots?${searchParams.toString()}`,
-      {
-        method: 'GET',
-      },
+      `${env.SERVER_URL}/parking-features?${searchParams.toString()}`,
+      {},
     );
 
     await genericApiErrorHandler(response);
 
     const responseData = await response.json();
 
-    const validationResult = parkingSpotListSchema.safeParse(responseData);
+    const validationResult = parkingFeatureListSchema.safeParse(responseData);
 
     if (!validationResult.success) {
       throw defaultServerError;

--- a/apps/manager-client/src/features/parking-features/schemas/index.ts
+++ b/apps/manager-client/src/features/parking-features/schemas/index.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+const levelsEnum = z.enum(['PARKING', 'PARKING_SPOT']);
+
+export const parkingFeatureListItemSchema = z.object({
+  id: z.uuid(),
+  name: z.string(),
+  levels: z.array(levelsEnum),
+  version: z.number().int().positive(),
+});
+
+export const parkingFeatureListSchema = z.object({
+  data: z.array(parkingFeatureListItemSchema),
+  total: z.number().int().nonnegative(),
+  currentPage: z.number().int().positive(),
+});
+
+export const parkingFeaturesListInputSchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce.number().int().positive().optional().default(30),
+  search: z.string().optional(),
+  levels: z.array(levelsEnum).optional(),
+});

--- a/apps/manager-client/src/features/parking-spots/api/index.ts
+++ b/apps/manager-client/src/features/parking-spots/api/index.ts
@@ -1,5 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import {
+  addParkingSpotInputSchema,
+  generalServerResponseSchema,
   parkingSpotListSchema,
   parkingSpotsListInputSchema,
 } from '#/features/parking-spots/schemas';
@@ -9,7 +11,7 @@ import {
   genericApiErrorHandler,
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
-import { createSearchParams } from '#/lib/utils.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getParkingSpotsForParking = createServerFn()
   .validator(parkingSpotsListInputSchema)
@@ -29,7 +31,35 @@ export const getParkingSpotsForParking = createServerFn()
 
     const responseData = await response.json();
 
+    console.log(responseData.data); // todo;
+
     const validationResult = parkingSpotListSchema.safeParse(responseData);
+
+    if (!validationResult.success) {
+      throw defaultServerError;
+    }
+
+    return validationResult.data;
+  });
+
+export const addParkingSpot = createServerFn()
+  .validator(addParkingSpotInputSchema)
+  .handler(async ({ data }) => {
+    const response = await authFetch(`${env.SERVER_URL}/parking-spots`, {
+      method: 'POST',
+      body: JSON.stringify({
+        parkingFeatureIds: data.parkingFeatureIds,
+        price: data.price,
+        parkingId: data.parkingId,
+      }),
+    });
+
+    await genericApiErrorHandler(response);
+
+    const responseData = await response.json();
+
+    const validationResult =
+      generalServerResponseSchema.safeParse(responseData);
 
     if (!validationResult.success) {
       throw defaultServerError;

--- a/apps/manager-client/src/features/parking-spots/api/index.ts
+++ b/apps/manager-client/src/features/parking-spots/api/index.ts
@@ -31,8 +31,6 @@ export const getParkingSpotsForParking = createServerFn()
 
     const responseData = await response.json();
 
-    console.log(responseData.data); // todo;
-
     const validationResult = parkingSpotListSchema.safeParse(responseData);
 
     if (!validationResult.success) {

--- a/apps/manager-client/src/features/parking-spots/components/add-parking-spot-modal.tsx
+++ b/apps/manager-client/src/features/parking-spots/components/add-parking-spot-modal.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from '@tanstack/react-form';
+import { useServerFn } from '@tanstack/react-start';
+import {
+  CheckIcon,
+  ChevronsUpDownIcon,
+  ParkingSquareIcon,
+  SearchIcon,
+  XIcon,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { Button } from '#/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#/components/ui/dialog.tsx';
+import { Field, FieldError, FieldLabel } from '#/components/ui/field.tsx';
+import { Input } from '#/components/ui/input.tsx';
+import { Spinner } from '#/components/ui/spinner.tsx';
+import { addParkingSpot } from '#/features/parking-spots/api';
+import { getParkingFeatures } from '#/features/parking-features/api';
+import type { parkingFeatureListItemSchema } from '#/features/parking-features/schemas';
+import { cn } from '#/lib/utils.ts';
+
+const PARKING_FEATURES_LIMIT = 20;
+
+const addParkingSpotFormSchema = z.object({
+  price: z.coerce
+    .number()
+    .int('Price must be a whole number')
+    .positive('Price must be greater than 0'),
+  parkingFeatureIds: z.array(z.uuid()),
+});
+
+type ParkingFeatureOption = z.infer<typeof parkingFeatureListItemSchema>;
+
+type Props = Readonly<{
+  open: boolean;
+  parkingId: string;
+  onOpenChange: (open: boolean) => void;
+  onParkingSpotAdded: () => Promise<void> | void;
+}>;
+
+export function AddParkingSpotModal({
+  open,
+  parkingId,
+  onOpenChange,
+  onParkingSpotAdded,
+}: Props) {
+  const addParkingSpotFn = useServerFn(addParkingSpot);
+  const getParkingFeaturesFn = useServerFn(getParkingFeatures);
+  const [featureSearch, setFeatureSearch] = useState('');
+  const [debouncedFeatureSearch, setDebouncedFeatureSearch] = useState('');
+  const [featuresOpen, setFeaturesOpen] = useState(false);
+  const [features, setFeatures] = useState<Array<ParkingFeatureOption>>([]);
+  const [selectedFeatures, setSelectedFeatures] = useState<
+    Record<string, ParkingFeatureOption>
+  >({});
+  const [featuresLoading, setFeaturesLoading] = useState(false);
+  const [featuresError, setFeaturesError] = useState<string | null>(null);
+
+  const form = useForm({
+    defaultValues: {
+      price: '',
+      parkingFeatureIds: [] as Array<string>,
+    },
+    validators: {
+      onSubmit: addParkingSpotFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      try {
+        await addParkingSpotFn({
+          data: {
+            parkingId,
+            price: Number(value.price),
+            parkingFeatureIds: value.parkingFeatureIds,
+          },
+        });
+        toast.success('Parking spot added');
+        resetModalState();
+        onOpenChange(false);
+        await onParkingSpotAdded();
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : 'Failed to add parking spot',
+        );
+      }
+    },
+  });
+
+  const selectedFeatureItems = useMemo(
+    () =>
+      form.state.values.parkingFeatureIds
+        .map((featureId) => selectedFeatures[featureId])
+        .filter((feature): feature is ParkingFeatureOption => Boolean(feature)),
+    [form.state.values.parkingFeatureIds, selectedFeatures],
+  );
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedFeatureSearch(featureSearch);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [featureSearch]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let isActive = true;
+
+    async function fetchParkingFeatures() {
+      setFeaturesLoading(true);
+      setFeaturesError(null);
+
+      try {
+        const response = await getParkingFeaturesFn({
+          data: {
+            page: 1,
+            limit: PARKING_FEATURES_LIMIT,
+            search: debouncedFeatureSearch,
+            levels: ['PARKING_SPOT'],
+          },
+        });
+
+        if (isActive) {
+          setFeatures(response.data);
+        }
+      } catch {
+        if (isActive) {
+          setFeatures([]);
+          setFeaturesError('Failed to load parking features.');
+        }
+      } finally {
+        if (isActive) {
+          setFeaturesLoading(false);
+        }
+      }
+    }
+
+    void fetchParkingFeatures();
+
+    return () => {
+      isActive = false;
+    };
+  }, [debouncedFeatureSearch, getParkingFeaturesFn, open]);
+
+  function resetModalState() {
+    form.reset();
+    setFeatureSearch('');
+    setDebouncedFeatureSearch('');
+    setFeaturesOpen(false);
+    setFeatures([]);
+    setSelectedFeatures({});
+    setFeaturesError(null);
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        onOpenChange(isOpen);
+        if (!isOpen) {
+          resetModalState();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <div className="mb-1 flex size-10 items-center justify-center rounded-md border bg-background text-primary shadow-xs">
+            <ParkingSquareIcon aria-hidden="true" className="size-5" />
+          </div>
+          <DialogTitle>Add parking spot</DialogTitle>
+        </DialogHeader>
+
+        <form
+          className="space-y-4"
+          onSubmit={async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            await form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="price"
+            children={(field) => {
+              const isInvalid =
+                field.state.meta.isTouched && !field.state.meta.isValid;
+
+              return (
+                <Field data-invalid={isInvalid}>
+                  <FieldLabel htmlFor={field.name}>Price</FieldLabel>
+                  <Input
+                    id={field.name}
+                    name={field.name}
+                    type="number"
+                    min={1}
+                    step={1}
+                    inputMode="numeric"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    aria-invalid={isInvalid}
+                  />
+                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                </Field>
+              );
+            }}
+          />
+
+          <form.Field
+            name="parkingFeatureIds"
+            children={(field) => {
+              const isInvalid =
+                field.state.meta.isTouched && !field.state.meta.isValid;
+
+              const toggleFeature = (feature: ParkingFeatureOption) => {
+                setSelectedFeatures((previous) => ({
+                  ...previous,
+                  [feature.id]: feature,
+                }));
+
+                field.handleChange(
+                  field.state.value.includes(feature.id)
+                    ? field.state.value.filter((id) => id !== feature.id)
+                    : [...field.state.value, feature.id],
+                );
+              };
+
+              return (
+                <Field data-invalid={isInvalid}>
+                  <FieldLabel>Parking features</FieldLabel>
+                  <div className="relative">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="h-auto min-h-9 w-full justify-between gap-3 px-3 py-2 text-left font-normal"
+                      aria-expanded={featuresOpen}
+                      onClick={() => setFeaturesOpen((value) => !value)}
+                    >
+                      <span
+                        className={cn(
+                          'min-w-0 flex-1 truncate text-sm',
+                          selectedFeatureItems.length === 0 &&
+                            'text-muted-foreground',
+                        )}
+                      >
+                        {selectedFeatureItems.length > 0
+                          ? selectedFeatureItems
+                              .map((feature) => feature.name)
+                              .join(', ')
+                          : 'Select parking features'}
+                      </span>
+                      <ChevronsUpDownIcon
+                        aria-hidden="true"
+                        className="size-4 shrink-0 text-muted-foreground"
+                      />
+                    </Button>
+
+                    {featuresOpen && (
+                      <div className="absolute z-50 mt-2 w-full rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+                        <div className="relative">
+                          <SearchIcon
+                            aria-hidden="true"
+                            className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                          />
+                          <Input
+                            value={featureSearch}
+                            onChange={(e) => setFeatureSearch(e.target.value)}
+                            placeholder="Search parking features"
+                            className="pl-9"
+                            autoFocus
+                          />
+                        </div>
+
+                        <div className="mt-2 max-h-60 overflow-y-auto">
+                          {featuresLoading ? (
+                            <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
+                              <Spinner className="size-4" />
+                              Loading features
+                            </div>
+                          ) : featuresError ? (
+                            <p className="px-2 py-3 text-sm text-destructive">
+                              {featuresError}
+                            </p>
+                          ) : features.length > 0 ? (
+                            <div className="space-y-1">
+                              {features.map((feature) => {
+                                const selected = field.state.value.includes(
+                                  feature.id,
+                                );
+
+                                return (
+                                  <button
+                                    key={feature.id}
+                                    type="button"
+                                    className="flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm outline-hidden hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
+                                    onClick={() => toggleFeature(feature)}
+                                  >
+                                    <span
+                                      className={cn(
+                                        'flex size-4 items-center justify-center rounded-sm border',
+                                        selected &&
+                                          'border-primary bg-primary text-primary-foreground',
+                                      )}
+                                    >
+                                      {selected && (
+                                        <CheckIcon
+                                          aria-hidden="true"
+                                          className="size-3"
+                                        />
+                                      )}
+                                    </span>
+                                    <span className="min-w-0 flex-1 truncate">
+                                      {feature.name}
+                                    </span>
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          ) : (
+                            <p className="px-2 py-3 text-sm text-muted-foreground">
+                              No features found.
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {selectedFeatureItems.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {selectedFeatureItems.map((feature) => (
+                        <button
+                          key={feature.id}
+                          type="button"
+                          className="inline-flex max-w-full items-center gap-1 rounded-md border bg-muted px-2 py-1 text-xs font-medium"
+                          onClick={() =>
+                            field.handleChange(
+                              field.state.value.filter(
+                                (featureId) => featureId !== feature.id,
+                              ),
+                            )
+                          }
+                        >
+                          <span className="truncate">{feature.name}</span>
+                          <XIcon
+                            aria-hidden="true"
+                            className="size-3 shrink-0 text-muted-foreground"
+                          />
+                        </button>
+                      ))}
+                    </div>
+                  )}
+
+                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                </Field>
+              );
+            }}
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                resetModalState();
+                onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={form.state.isSubmitting}>
+              {form.state.isSubmitting && <Spinner className="mr-2" />}
+              Add spot
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/manager-client/src/features/parking-spots/schemas/index.ts
+++ b/apps/manager-client/src/features/parking-spots/schemas/index.ts
@@ -24,3 +24,13 @@ export const parkingSpotsListInputSchema = z.object({
   page: z.coerce.number().int().positive().optional().default(1),
   limit: z.coerce.number().int().positive().optional().default(30),
 });
+
+export const addParkingSpotInputSchema = z.object({
+  parkingFeatureIds: z.array(z.uuid()),
+  price: z.number().int().positive(),
+  parkingId: z.uuid(),
+});
+
+export const generalServerResponseSchema = z.object({
+  id: z.uuid(),
+});

--- a/apps/manager-client/src/features/parking/api/index.ts
+++ b/apps/manager-client/src/features/parking/api/index.ts
@@ -5,13 +5,13 @@ import {
   parkingListBaseInputSchema,
   parkingListSchema,
 } from '#/features/parking/schemas';
-import { createSearchParams } from '#/lib/utils.ts';
 import {
   authFetch,
   defaultServerError,
   genericApiErrorHandler,
 } from '#/lib/auth-fetch.ts';
 import { env } from '#/env.ts';
+import { createSearchParams } from '@repo/frontend-utils';
 
 export const getParkings = createServerFn()
   .validator(parkingListBaseInputSchema)

--- a/apps/manager-client/src/lib/utils.ts
+++ b/apps/manager-client/src/lib/utils.ts
@@ -6,16 +6,21 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function createSearchParams<T extends Record<string, string | number>>(
-  data: T,
-): URLSearchParams {
-  const searchParams = new URLSearchParams();
-
-  for (const [key, value] of Object.entries(data)) {
-    if (value) {
-      searchParams.append(key, value.toString());
-    }
-  }
-
-  return searchParams;
-}
+// todo: move to dedicated package
+// export function createSearchParams<
+//   T extends Record<string, string | number | (string | number)[]>,
+// >(data: T): URLSearchParams {
+//   const searchParams = new URLSearchParams();
+//
+//   for (const [key, value] of Object.entries(data)) {
+//     if (value && (typeof value === 'string' || typeof value === 'number')) {
+//       searchParams.append(key, value.toString());
+//     } else if (Array.isArray(value)) {
+//       value.forEach((item) => {
+//         searchParams.append(key, item.toString());
+//       });
+//     }
+//   }
+//
+//   return searchParams;
+// }

--- a/apps/manager-client/src/lib/utils.ts
+++ b/apps/manager-client/src/lib/utils.ts
@@ -5,22 +5,3 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-// todo: move to dedicated package
-// export function createSearchParams<
-//   T extends Record<string, string | number | (string | number)[]>,
-// >(data: T): URLSearchParams {
-//   const searchParams = new URLSearchParams();
-//
-//   for (const [key, value] of Object.entries(data)) {
-//     if (value && (typeof value === 'string' || typeof value === 'number')) {
-//       searchParams.append(key, value.toString());
-//     } else if (Array.isArray(value)) {
-//       value.forEach((item) => {
-//         searchParams.append(key, item.toString());
-//       });
-//     }
-//   }
-//
-//   return searchParams;
-// }

--- a/apps/manager-client/src/routes/_protected/app/$organizationId/parkings/$parkingId.tsx
+++ b/apps/manager-client/src/routes/_protected/app/$organizationId/parkings/$parkingId.tsx
@@ -1,4 +1,9 @@
-import { Link, createFileRoute, redirect } from '@tanstack/react-router';
+import {
+  Link,
+  createFileRoute,
+  redirect,
+  useRouter,
+} from '@tanstack/react-router';
 import {
   ArrowLeftIcon,
   Building2Icon,
@@ -8,6 +13,7 @@ import {
   FileTextIcon,
   Layers3Icon,
   MapPinIcon,
+  ParkingSquareIcon,
   PencilIcon,
   PlusIcon,
   ShieldCheckIcon,
@@ -16,6 +22,7 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { useState } from 'react';
 import { z } from 'zod';
 
 import { Alert, AlertDescription, AlertTitle } from '#/components/ui/alert.tsx';
@@ -31,6 +38,7 @@ import { Separator } from '#/components/ui/separator.tsx';
 import { Spinner } from '#/components/ui/spinner.tsx';
 import { getParkingDetails } from '#/features/parking/api';
 import { getParkingSpotsForParking } from '#/features/parking-spots/api';
+import { AddParkingSpotModal } from '#/features/parking-spots/components/add-parking-spot-modal.tsx';
 
 const PARKING_SPOTS_PAGE_SIZE = 24;
 
@@ -119,6 +127,8 @@ export const Route = createFileRoute(
 function RouteComponent() {
   const { organizationId } = Route.useParams();
   const navigate = Route.useNavigate();
+  const router = useRouter();
+  const [addParkingSpotOpen, setAddParkingSpotOpen] = useState(false);
   const {
     parking,
     parkingSpots,
@@ -178,6 +188,7 @@ function RouteComponent() {
           <ActionButton
             enabled={parking.actions.addParkingSpot}
             icon={PlusIcon}
+            onClick={() => setAddParkingSpotOpen(true)}
           >
             Add spot
           </ActionButton>
@@ -368,9 +379,6 @@ function RouteComponent() {
                           className="size-5 text-muted-foreground"
                         />
                       </div>
-                      <CardTitle className="break-all text-base">
-                        Spot {parkingSpot.id}
-                      </CardTitle>
                     </div>
                     <ParkingStatus active={parkingSpot.active} />
                   </div>
@@ -380,10 +388,6 @@ function RouteComponent() {
                     <DetailItem
                       label="Price"
                       value={formatPrice(parkingSpot.price)}
-                    />
-                    <DetailItem
-                      label="Version"
-                      value={parkingSpot.version.toString()}
                     />
                   </div>
                   <TagGroup
@@ -398,6 +402,15 @@ function RouteComponent() {
           </div>
         ) : null}
       </section>
+
+      <AddParkingSpotModal
+        open={addParkingSpotOpen}
+        parkingId={parking.id}
+        onOpenChange={setAddParkingSpotOpen}
+        onParkingSpotAdded={async () => {
+          await router.invalidate();
+        }}
+      />
     </div>
   );
 }
@@ -422,15 +435,17 @@ function ActionButton({
   children,
   enabled,
   icon: Icon,
+  onClick,
   variant = 'outline',
 }: Readonly<{
   children: ReactNode;
   enabled: boolean;
   icon: LucideIcon;
+  onClick?: () => void;
   variant?: 'outline' | 'destructive';
 }>) {
   return (
-    <Button variant={variant} size="sm" disabled={!enabled}>
+    <Button variant={variant} size="sm" disabled={!enabled} onClick={onClick}>
       <Icon aria-hidden="true" />
       {children}
     </Button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
     },
     "apps/admin-client": {
       "dependencies": {
+        "@repo/frontend-utils": "^1.0.0",
         "@t3-oss/env-core": "^0.13.11",
         "@tailwindcss/vite": "^4.3.1",
         "@tanstack/react-devtools": "^0.10.5",
@@ -911,6 +912,7 @@
     "apps/manager-client": {
       "dependencies": {
         "@faker-js/faker": "^10.4.0",
+        "@repo/frontend-utils": "^1.0.0",
         "@t3-oss/env-core": "^0.13.11",
         "@tailwindcss/vite": "^4.3.1",
         "@tanstack/match-sorter-utils": "latest",
@@ -12951,6 +12953,10 @@
     },
     "node_modules/@repo/eslint-config": {
       "resolved": "packages/eslint-config",
+      "link": true
+    },
+    "node_modules/@repo/frontend-utils": {
+      "resolved": "packages/frontend-utils",
       "link": true
     },
     "node_modules/@repo/typescript-config": {
@@ -32634,6 +32640,29 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/frontend-utils": {
+      "name": "@repo/frontend-utils",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@repo/typescript-config": "*",
+        "typescript": "^6.0.3"
+      }
+    },
+    "packages/frontend-utils/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/frontend-utils/package.json
+++ b/packages/frontend-utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@repo/frontend-utils",
+  "version": "1.0.0",
+  "author": "SPECTRE-IT",
+  "private": true,
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "*",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/frontend-utils/src/index.ts
+++ b/packages/frontend-utils/src/index.ts
@@ -1,0 +1,17 @@
+export function createSearchParams<
+  T extends Record<string, string | number | (string | number)[]>,
+>(data: T): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(data)) {
+    if (value && (typeof value === "string" || typeof value === "number")) {
+      searchParams.append(key, value.toString());
+    } else if (Array.isArray(value)) {
+      value.forEach((item) => {
+        searchParams.append(key, item.toString());
+      });
+    }
+  }
+
+  return searchParams;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Add spot” modal on the parking details page with parking feature selection and price input.
* **Improvements**
  * Updated parking spot cards to remove extra identifiers and the per-spot version row.
  * Parking feature listing filtering by “levels” is more flexible and more accurate per request.
* **Bug Fixes**
  * Parking spot feature data is now correctly scoped to each spot.
* **Refactor**
  * Consolidated the shared `createSearchParams` utility into a reusable frontend package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->