### PR TITLE
278-manager-client-display-uploaded-images

### DIFF
--- a/apps/api/src/bff/manager-api/endpoints/assets/assets.controller.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/assets.controller.ts
@@ -113,12 +113,17 @@ export class AssetsController {
     @Query() query: GetAssetImageQueryDto,
     @Res() res: Response,
   ) {
-    const { buffer, mimeType } = await this.getAssetImageHandler.handle(
-      assetId,
-      query.width,
-      query.height,
-    );
+    const { buffer, mimeType, etag, cacheControl } =
+      await this.getAssetImageHandler.handle(
+        assetId,
+        query.width,
+        query.height,
+      );
+
     res.set('Content-Type', mimeType);
+    res.set('ETag', etag);
+    res.set('Cache-Control', cacheControl);
+
     res.send(buffer);
   }
 }

--- a/apps/api/src/bff/manager-api/endpoints/assets/assets.controller.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/assets.controller.ts
@@ -1,8 +1,13 @@
 import {
   Controller,
   FileTypeValidator,
+  Get,
+  Param,
   ParseFilePipe,
+  ParseUUIDPipe,
   Post,
+  Query,
+  Res,
   UploadedFile,
   UseGuards,
   UseInterceptors,
@@ -11,21 +16,29 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import type { Response } from 'express';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
-import { AssetFacade } from 'src/modules/asset/application/asset.facade';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { GetAssetImageQueryDto } from './dto/get-asset-image-query.dto';
+import { GetAssetImageHandler } from './handlers/get-asset-image.handler';
+import { UploadAssetHandler } from './handlers/upload-asset.handler';
 
 @ApiBearerAuth('manager-auth')
 @ApiTags('Assets')
 @UseGuards(JwtAuthGuard)
 @Controller('manager/assets')
 export class AssetsController {
-  constructor(private readonly assetFacade: AssetFacade) {}
+  constructor(
+    private readonly getAssetImageHandler: GetAssetImageHandler,
+    private readonly uploadAssetHandler: UploadAssetHandler,
+  ) {}
 
   @ApiOperation({ summary: 'Upload an image asset' })
   @ApiCreatedResponse({
@@ -70,9 +83,42 @@ export class AssetsController {
     )
     file: Express.Multer.File,
   ) {
-    const id = await this.assetFacade.uploadAsset(file, 'onlyImage');
-    return {
-      id,
-    };
+    return await this.uploadAssetHandler.handle(file);
+  }
+
+  @ApiOperation({ summary: 'Get an image asset' })
+  @ApiOkResponse({
+    description: 'Returns the image asset',
+    content: {
+      'image/*': {
+        schema: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid asset ID or query parameters.',
+  })
+  @ApiNotFoundResponse({
+    description: 'Asset not found.',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Unauthorized access. Please provide a valid JWT token.',
+  })
+  @Get(':assetId')
+  async getAssetImage(
+    @Param('assetId', new ParseUUIDPipe()) assetId: string,
+    @Query() query: GetAssetImageQueryDto,
+    @Res() res: Response,
+  ) {
+    const { buffer, mimeType } = await this.getAssetImageHandler.handle(
+      assetId,
+      query.width,
+      query.height,
+    );
+    res.set('Content-Type', mimeType);
+    res.send(buffer);
   }
 }

--- a/apps/api/src/bff/manager-api/endpoints/assets/assets.controller.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/assets.controller.ts
@@ -29,6 +29,8 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { GetAssetImageQueryDto } from './dto/get-asset-image-query.dto';
 import { GetAssetImageHandler } from './handlers/get-asset-image.handler';
 import { UploadAssetHandler } from './handlers/upload-asset.handler';
+import { CurrentManagerUser } from 'src/bff/manager-api/auth/decorators/current-manager-user.decorator';
+import type { RequestUser } from 'src/bff/manager-api/auth/types';
 
 @ApiBearerAuth('manager-auth')
 @ApiTags('Assets')
@@ -112,10 +114,12 @@ export class AssetsController {
     @Param('assetId', new ParseUUIDPipe()) assetId: string,
     @Query() query: GetAssetImageQueryDto,
     @Res() res: Response,
+    @CurrentManagerUser() managerUser: RequestUser,
   ) {
     const { buffer, mimeType, etag, cacheControl } =
       await this.getAssetImageHandler.handle(
         assetId,
+        managerUser,
         query.width,
         query.height,
       );

--- a/apps/api/src/bff/manager-api/endpoints/assets/dto/get-asset-image-query.dto.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/dto/get-asset-image-query.dto.ts
@@ -1,0 +1,31 @@
+import { IsInt, IsOptional, IsPositive, Max } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class GetAssetImageQueryDto {
+  @ApiPropertyOptional({
+    description: 'Width of the image in pixels',
+    example: 800,
+    minimum: 1,
+    maximum: 1920,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  @Max(1920)
+  readonly width?: number;
+
+  @ApiPropertyOptional({
+    description: 'Height of the image in pixels',
+    example: 600,
+    minimum: 1,
+    maximum: 1080,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  @Max(1080)
+  readonly height?: number;
+}

--- a/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
@@ -11,7 +11,12 @@ export class GetAssetImageHandler implements IControllerHandler {
     assetId: string,
     width?: number,
     height?: number,
-  ): Promise<QueryAssetResponse> {
-    return await this.assetFacade.getAssetImage(assetId, width, height);
+  ): Promise<QueryAssetResponse & { cacheControl: string }> {
+    const asset = await this.assetFacade.getAssetImage(assetId, width, height);
+
+    return {
+      ...asset,
+      cacheControl: 'public, max-age=31536000',
+    };
   }
 }

--- a/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { IControllerHandler } from 'src/shared/controller-handler.interface';
 import { AssetFacade } from 'src/modules/asset/application/asset.facade';
 import { QueryAssetResponse } from 'src/modules/asset/types';
+import { RequestUser } from 'src/bff/manager-api/auth/types';
 
 @Injectable()
 export class GetAssetImageHandler implements IControllerHandler {
@@ -9,10 +10,16 @@ export class GetAssetImageHandler implements IControllerHandler {
 
   async handle(
     assetId: string,
+    managerUser: RequestUser,
     width?: number,
     height?: number,
   ): Promise<QueryAssetResponse & { cacheControl: string }> {
-    const asset = await this.assetFacade.getAssetImage(assetId, width, height);
+    const asset = await this.assetFacade.getAssetImage(
+      assetId,
+      managerUser.id,
+      width,
+      height,
+    );
 
     return {
       ...asset,

--- a/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
@@ -16,7 +16,7 @@ export class GetAssetImageHandler implements IControllerHandler {
 
     return {
       ...asset,
-      cacheControl: 'public, max-age=31536000',
+      cacheControl: 'private, max-age=31536000',
     };
   }
 }

--- a/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/handlers/get-asset-image.handler.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { IControllerHandler } from 'src/shared/controller-handler.interface';
+import { AssetFacade } from 'src/modules/asset/application/asset.facade';
+import { QueryAssetResponse } from 'src/modules/asset/types';
+
+@Injectable()
+export class GetAssetImageHandler implements IControllerHandler {
+  constructor(private readonly assetFacade: AssetFacade) {}
+
+  async handle(
+    assetId: string,
+    width?: number,
+    height?: number,
+  ): Promise<QueryAssetResponse> {
+    return await this.assetFacade.getAssetImage(assetId, width, height);
+  }
+}

--- a/apps/api/src/bff/manager-api/endpoints/assets/handlers/upload-asset.handler.ts
+++ b/apps/api/src/bff/manager-api/endpoints/assets/handlers/upload-asset.handler.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { IControllerHandler } from 'src/shared/controller-handler.interface';
+import { AssetFacade } from 'src/modules/asset/application/asset.facade';
+
+@Injectable()
+export class UploadAssetHandler implements IControllerHandler {
+  constructor(private readonly assetFacade: AssetFacade) {}
+
+  async handle(file: Express.Multer.File): Promise<{ id: string }> {
+    const id = await this.assetFacade.uploadAsset(file, 'onlyImage');
+    return {
+      id,
+    };
+  }
+}

--- a/apps/api/src/bff/manager-api/manager-api.module.ts
+++ b/apps/api/src/bff/manager-api/manager-api.module.ts
@@ -23,6 +23,8 @@ import { GetParkingSpotsHandler } from './endpoints/parking-spots/handlers/get-p
 import { AssetsController } from './endpoints/assets/assets.controller';
 import { AssetModule } from 'src/modules/asset/application/asset.module';
 import { UpdateParkingHandler } from './endpoints/parkings/handlers/update-parking.handler';
+import { GetAssetImageHandler } from './endpoints/assets/handlers/get-asset-image.handler';
+import { UploadAssetHandler } from './endpoints/assets/handlers/upload-asset.handler';
 import { ActivateParkingSpotHandler } from './endpoints/parking-spots/handlers/activate-parking-spot.handler';
 import { DeactivateParkingSpotHandler } from './endpoints/parking-spots/handlers/deactivate-parking-spot.handler';
 import { ActivateAndDeactivateParkingSpotService } from './endpoints/parking-spots/handlers/shared/activate-and-deactivate-parking-spot.service';
@@ -57,6 +59,8 @@ import { ActivateAndDeactivateParkingSpotService } from './endpoints/parking-spo
     GetParkingFeaturesListHandler,
     GetParkingSpotsHandler,
     UpdateParkingHandler,
+    GetAssetImageHandler,
+    UploadAssetHandler,
     ActivateParkingSpotHandler,
     DeactivateParkingSpotHandler,
     ActivateAndDeactivateParkingSpotService,

--- a/apps/api/src/modules/asset/application/asset.facade.ts
+++ b/apps/api/src/modules/asset/application/asset.facade.ts
@@ -32,9 +32,14 @@ export class AssetFacade {
     );
   }
 
-  async getAssetImage(assetId: string, width?: number, height?: number) {
+  async getAssetImage(
+    assetId: string,
+    userId: string,
+    width?: number,
+    height?: number,
+  ) {
     return await this.queryBus.execute<GetAssetImageQuery, QueryAssetResponse>(
-      new GetAssetImageQuery(assetId, width, height),
+      new GetAssetImageQuery(assetId, userId, width, height),
     );
   }
 

--- a/apps/api/src/modules/asset/application/ports/assets.storage.ts
+++ b/apps/api/src/modules/asset/application/ports/assets.storage.ts
@@ -1,0 +1,31 @@
+export abstract class AssetsStorage {
+  abstract insertImage(
+    assetId: string,
+    userId: string,
+    buffer: Buffer,
+    width?: number,
+    height?: number,
+  ): Promise<void>;
+
+  abstract getImage(
+    assetId: string,
+    userId: string,
+    width?: number,
+    height?: number,
+  ): Promise<Buffer | null>;
+
+  abstract insertImageEtag(
+    assetId: string,
+    userId: string,
+    etag: string,
+    width?: number,
+    height?: number,
+  ): Promise<void>;
+
+  abstract getImageEtag(
+    assetId: string,
+    userId: string,
+    width?: number,
+    height?: number,
+  ): Promise<string | null>;
+}

--- a/apps/api/src/modules/asset/application/queries/get-asset-image.query.ts
+++ b/apps/api/src/modules/asset/application/queries/get-asset-image.query.ts
@@ -25,10 +25,14 @@ export class GetAssetImageQuery implements IQuery {
   @Max(1080)
   readonly height?: number;
 
-  constructor(id: string, width?: number, height?: number) {
+  @IsUUID()
+  readonly userId: string;
+
+  constructor(id: string, userId: string, width?: number, height?: number) {
     this.id = id;
     this.width = width;
     this.height = height;
+    this.userId = userId;
     this.validate();
   }
 

--- a/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
+++ b/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
@@ -43,7 +43,7 @@ export class GetAssetImageQueryHandler implements IQueryHandler<
       height,
     );
 
-    const etag = createHash('md5').update(updatedBuffer).digest('hex');
+    const etag = `"${createHash('md5').update(updatedBuffer).digest('hex')}"`;
 
     return {
       id: record.id,

--- a/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
+++ b/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
@@ -5,6 +5,7 @@ import { FileUploader } from '../ports/file-uploader';
 import { ImageProcessing } from '../ports/image-processing';
 import { AppError } from 'src/shared/errors';
 import { QueryAssetResponse } from '../../types';
+import { createHash } from 'node:crypto';
 
 @QueryHandler(GetAssetImageQuery)
 export class GetAssetImageQueryHandler implements IQueryHandler<
@@ -42,10 +43,13 @@ export class GetAssetImageQueryHandler implements IQueryHandler<
       height,
     );
 
+    const etag = createHash('md5').update(updatedBuffer).digest('hex');
+
     return {
       id: record.id,
       mimeType: record.mimeType,
       buffer: updatedBuffer,
+      etag,
     };
   }
 }

--- a/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
+++ b/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
@@ -6,6 +6,7 @@ import { ImageProcessing } from '../ports/image-processing';
 import { AppError } from 'src/shared/errors';
 import { QueryAssetResponse } from '../../types';
 import { createHash } from 'node:crypto';
+import { AssetsStorage } from '../ports/assets.storage';
 
 @QueryHandler(GetAssetImageQuery)
 export class GetAssetImageQueryHandler implements IQueryHandler<
@@ -16,10 +17,11 @@ export class GetAssetImageQueryHandler implements IQueryHandler<
     private readonly prismaService: PrismaService,
     private readonly fileUploader: FileUploader,
     private readonly imageProcessing: ImageProcessing,
+    private readonly assetsStorage: AssetsStorage,
   ) {}
 
   async execute(query: GetAssetImageQuery): Promise<QueryAssetResponse> {
-    const { id, width, height } = query;
+    const { id, width, height, userId } = query;
 
     const record = await this.prismaService.asset.findUnique({
       where: {
@@ -35,6 +37,31 @@ export class GetAssetImageQueryHandler implements IQueryHandler<
       throw new AppError('VALIDATION_ERROR', 'Asset is not an image');
     }
 
+    const cachedBuffer = await this.assetsStorage.getImage(
+      id,
+      userId,
+      width,
+      height,
+    );
+
+    const cachedEtag = await this.assetsStorage.getImageEtag(
+      id,
+      userId,
+      width,
+      height,
+    );
+
+    if (cachedBuffer && cachedEtag) {
+      return {
+        id: record.id,
+        mimeType: record.mimeType,
+        buffer: cachedBuffer,
+        etag: cachedEtag,
+      };
+    }
+
+    console.log('reading data from s3'); // todo: remove it
+
     const buffer = await this.fileUploader.getObjectFromStorage(record.key);
 
     const updatedBuffer = await this.imageProcessing.resize(
@@ -44,6 +71,22 @@ export class GetAssetImageQueryHandler implements IQueryHandler<
     );
 
     const etag = `"${createHash('md5').update(updatedBuffer).digest('hex')}"`;
+
+    await this.assetsStorage.insertImage(
+      record.id,
+      userId,
+      updatedBuffer,
+      width,
+      height,
+    );
+
+    await this.assetsStorage.insertImageEtag(
+      record.id,
+      userId,
+      etag,
+      width,
+      height,
+    );
 
     return {
       id: record.id,

--- a/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
+++ b/apps/api/src/modules/asset/application/query-handlers/get-asset-image.query-handler.ts
@@ -60,8 +60,6 @@ export class GetAssetImageQueryHandler implements IQueryHandler<
       };
     }
 
-    console.log('reading data from s3'); // todo: remove it
-
     const buffer = await this.fileUploader.getObjectFromStorage(record.key);
 
     const updatedBuffer = await this.imageProcessing.resize(

--- a/apps/api/src/modules/asset/application/query-handlers/get-asset.query-handler.ts
+++ b/apps/api/src/modules/asset/application/query-handlers/get-asset.query-handler.ts
@@ -4,6 +4,7 @@ import { FileUploader } from '../ports/file-uploader';
 import { PrismaService } from 'src/shared/prisma/prisma.service';
 import { AppError } from 'src/shared/errors';
 import { QueryAssetResponse } from '../../types';
+import { createHash } from 'node:crypto';
 
 @QueryHandler(GetAssetQuery)
 export class GetAssetQueryHandler implements IQueryHandler<
@@ -30,10 +31,13 @@ export class GetAssetQueryHandler implements IQueryHandler<
 
     const buffer = await this.fileUploader.getObjectFromStorage(record.key);
 
+    const etag = createHash('md5').update(buffer).digest('hex');
+
     return {
       id: record.id,
       mimeType: record.mimeType,
       buffer,
+      etag,
     };
   }
 }

--- a/apps/api/src/modules/asset/infrastructure/infrastructure.module.ts
+++ b/apps/api/src/modules/asset/infrastructure/infrastructure.module.ts
@@ -6,6 +6,8 @@ import { ImageProcessing } from '../application/ports/image-processing';
 import { SharpImageProcessing } from './sharp-image-processing';
 import { AssetRepository } from '../application/ports/asset.repository';
 import { PrismaAssetRepository } from './persistance/prisma-asset.repository';
+import { AssetsStorage } from '../application/ports/assets.storage';
+import { RedisAssetsStorage } from './redis-assets.storage';
 
 @Module({
   imports: [PrismaModule],
@@ -22,7 +24,11 @@ import { PrismaAssetRepository } from './persistance/prisma-asset.repository';
       provide: AssetRepository,
       useClass: PrismaAssetRepository,
     },
+    {
+      provide: AssetsStorage,
+      useClass: RedisAssetsStorage,
+    },
   ],
-  exports: [FileUploader, ImageProcessing, AssetRepository],
+  exports: [FileUploader, ImageProcessing, AssetRepository, AssetsStorage],
 })
 export class InfrastructureModule {}

--- a/apps/api/src/modules/asset/infrastructure/redis-assets.storage.ts
+++ b/apps/api/src/modules/asset/infrastructure/redis-assets.storage.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+import { AssetsStorage } from '../application/ports/assets.storage';
+import { ConfigService } from '@nestjs/config';
+import { Redis } from 'ioredis';
+
+const TTL_SECONDS = 3 * 60 * 60;
+
+@Injectable()
+export class RedisAssetsStorage implements AssetsStorage {
+  private readonly client: Redis;
+
+  constructor(configService: ConfigService) {
+    const redisUrl = configService.get<string>('REDIS_URL');
+    if (!redisUrl) {
+      throw new Error('REDIS_URL is not defined in the environment variables');
+    }
+    this.client = new Redis(redisUrl);
+  }
+
+  async insertImage(
+    assetId: string,
+    userId: string,
+    buffer: Buffer,
+    width?: number,
+    height?: number,
+  ) {
+    await this.client.set(
+      this.getImageKey(assetId, userId, width, height),
+      buffer,
+      'EX',
+      TTL_SECONDS,
+    );
+  }
+
+  async getImage(
+    assetId: string,
+    userId: string,
+    width?: number,
+    height?: number,
+  ): Promise<Buffer | null> {
+    return await this.client.getBuffer(
+      this.getImageKey(assetId, userId, width, height),
+    );
+  }
+
+  async insertImageEtag(
+    assetId: string,
+    userId: string,
+    etag: string,
+    width?: number,
+    height?: number,
+  ) {
+    await this.client.set(
+      this.getImageEtagKey(assetId, userId, width, height),
+      etag,
+      'EX',
+      TTL_SECONDS,
+    );
+  }
+
+  async getImageEtag(
+    assetId: string,
+    userId: string,
+    width?: number,
+    height?: number,
+  ) {
+    return await this.client.get(
+      this.getImageEtagKey(assetId, userId, width, height),
+    );
+  }
+
+  private getImageKey(
+    assetId: string,
+    userId: string,
+    width?: number,
+    height?: number,
+  ) {
+    return `${assetId}:${userId}:${width ?? ''}:${height ?? ''}:image`;
+  }
+
+  private getImageEtagKey(
+    assetId: string,
+    userId: string,
+    width?: number,
+    height?: number,
+  ) {
+    return `${assetId}:${userId}:${width ?? ''}:${height ?? ''}:etag`;
+  }
+}

--- a/apps/api/src/modules/asset/types/index.ts
+++ b/apps/api/src/modules/asset/types/index.ts
@@ -2,6 +2,7 @@ export type QueryAssetResponse = {
   id: string;
   mimeType: string;
   buffer: Buffer;
+  etag: string;
 };
 
 export type UploadValidationStrategyOptions = 'all' | 'onlyImage';

--- a/apps/manager-client/src/features/assets/api/index.ts
+++ b/apps/manager-client/src/features/assets/api/index.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import {
+  getImageInputSchema,
   uploadImageInputSchema,
   uploadImageResponseSchema,
 } from '#/features/assets/schemas';
@@ -40,4 +41,16 @@ export const uploadImage = createServerFn({ method: 'POST' })
     }
 
     return validationResult.data;
+  });
+
+export const getImage = createServerFn()
+  .validator(getImageInputSchema)
+  .handler(async ({ data }) => {
+    const response = await authFetch(
+      `${env.SERVER_URL}/assets/${data.assetId}`,
+      {
+        method: 'GET',
+      },
+    );
+    return await response.json();
   });

--- a/apps/manager-client/src/features/assets/api/index.ts
+++ b/apps/manager-client/src/features/assets/api/index.ts
@@ -46,11 +46,24 @@ export const uploadImage = createServerFn({ method: 'POST' })
 export const getImage = createServerFn()
   .validator(getImageInputSchema)
   .handler(async ({ data }) => {
-    const response = await authFetch(
-      `${env.SERVER_URL}/assets/${data.assetId}`,
-      {
-        method: 'GET',
-      },
-    );
-    return await response.json();
+    const url = new URL(`${env.SERVER_URL}/assets/${data.assetId}`);
+
+    if (data.width) {
+      url.searchParams.set('width', data.width.toString());
+    }
+
+    if (data.height) {
+      url.searchParams.set('height', data.height.toString());
+    }
+
+    const response = await authFetch(url, {
+      method: 'GET',
+    });
+
+    await genericApiErrorHandler(response, 'Failed to load image.');
+
+    const contentType = response.headers.get('content-type') ?? 'image/jpeg';
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    return `data:${contentType};base64,${buffer.toString('base64')}`;
   });

--- a/apps/manager-client/src/features/assets/components/asset-image.tsx
+++ b/apps/manager-client/src/features/assets/components/asset-image.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ImageIcon } from 'lucide-react';
+import { useServerFn } from '@tanstack/react-start';
+
+import { Spinner } from '#/components/ui/spinner.tsx';
+import { getImage } from '#/features/assets/api';
+import { cn } from '#/lib/utils.ts';
+
+type AssetImageProps = Readonly<{
+  assetId: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  className?: string;
+}>;
+
+export function AssetImage({
+  assetId,
+  alt,
+  width,
+  height,
+  className,
+}: AssetImageProps) {
+  const getImageFn = useServerFn(getImage);
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let isActive = true;
+
+    setSrc(null);
+    setFailed(false);
+
+    async function loadImage() {
+      try {
+        const imageSrc = await getImageFn({
+          data: {
+            assetId,
+            width,
+            height,
+          },
+        });
+
+        if (isActive) {
+          setSrc(imageSrc);
+        }
+      } catch {
+        if (isActive) {
+          setFailed(true);
+        }
+      }
+    }
+
+    void loadImage();
+
+    return () => {
+      isActive = false;
+    };
+  }, [assetId, getImageFn, height, width]);
+
+  return (
+    <div
+      className={cn(
+        'relative flex aspect-video overflow-hidden rounded-md border bg-muted',
+        className,
+      )}
+    >
+      {src ? (
+        <img src={src} alt={alt} className="h-full w-full object-cover" />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+          {failed ? (
+            <ImageIcon aria-hidden="true" className="size-5" />
+          ) : (
+            <Spinner className="size-5" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/manager-client/src/features/assets/schemas/index.ts
+++ b/apps/manager-client/src/features/assets/schemas/index.ts
@@ -7,3 +7,5 @@ export const uploadImageInputSchema = z.object({
 export const uploadImageResponseSchema = z.object({
   id: z.uuid(),
 });
+
+export const getImageInputSchema = z.object({ assetId: z.uuid() });

--- a/apps/manager-client/src/features/assets/schemas/index.ts
+++ b/apps/manager-client/src/features/assets/schemas/index.ts
@@ -8,4 +8,8 @@ export const uploadImageResponseSchema = z.object({
   id: z.uuid(),
 });
 
-export const getImageInputSchema = z.object({ assetId: z.uuid() });
+export const getImageInputSchema = z.object({
+  assetId: z.uuid(),
+  width: z.number().min(1).max(1920).optional(),
+  height: z.number().min(1).max(1080).optional(),
+});

--- a/apps/manager-client/src/features/parking/components/edit-parking-modal.tsx
+++ b/apps/manager-client/src/features/parking/components/edit-parking-modal.tsx
@@ -26,6 +26,7 @@ import { Field, FieldError, FieldLabel } from '#/components/ui/field.tsx';
 import { Input } from '#/components/ui/input.tsx';
 import { Spinner } from '#/components/ui/spinner.tsx';
 import { Textarea } from '#/components/ui/textarea.tsx';
+import { AssetImage } from '#/features/assets/components/asset-image.tsx';
 import { uploadImage } from '#/features/assets/api';
 import { getParkingFeatures } from '#/features/parking-features/api';
 import type { parkingFeatureListItemSchema } from '#/features/parking-features/schemas';
@@ -503,28 +504,35 @@ export function EditParkingModal({
                         </div>
 
                         {assetField.state.value.length > 0 && (
-                          <div className="flex flex-wrap gap-2">
+                          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                             {assetField.state.value.map((assetId) => (
-                              <button
+                              <div
                                 key={assetId}
-                                type="button"
-                                className="inline-flex max-w-full items-center gap-1 rounded-md border bg-muted px-2 py-1 text-xs font-medium"
-                                onClick={() =>
-                                  assetField.handleChange(
-                                    assetField.state.value.filter(
-                                      (id) => id !== assetId,
-                                    ),
-                                  )
-                                }
+                                className="group relative overflow-hidden rounded-md"
                               >
-                                <span className="max-w-48 truncate">
-                                  {assetId}
-                                </span>
-                                <XIcon
-                                  aria-hidden="true"
-                                  className="size-3 shrink-0 text-muted-foreground"
+                                <AssetImage
+                                  assetId={assetId}
+                                  alt="Linked parking asset"
+                                  width={320}
+                                  height={180}
                                 />
-                              </button>
+                                <Button
+                                  type="button"
+                                  size="icon"
+                                  variant="secondary"
+                                  className="absolute right-1.5 top-1.5 size-7 shadow-sm"
+                                  aria-label="Remove image"
+                                  onClick={() =>
+                                    assetField.handleChange(
+                                      assetField.state.value.filter(
+                                        (id) => id !== assetId,
+                                      ),
+                                    )
+                                  }
+                                >
+                                  <XIcon aria-hidden="true" className="size-4" />
+                                </Button>
+                              </div>
                             ))}
                           </div>
                         )}

--- a/apps/manager-client/src/routes/_protected/app/$organizationId/parkings/$parkingId.tsx
+++ b/apps/manager-client/src/routes/_protected/app/$organizationId/parkings/$parkingId.tsx
@@ -12,6 +12,7 @@ import {
   CheckCircle2Icon,
   CircleSlashIcon,
   FileTextIcon,
+  ImageIcon,
   Layers3Icon,
   MapPinIcon,
   ParkingSquareIcon,
@@ -38,6 +39,7 @@ import {
 } from '#/components/ui/card.tsx';
 import { Separator } from '#/components/ui/separator.tsx';
 import { Spinner } from '#/components/ui/spinner.tsx';
+import { AssetImage } from '#/features/assets/components/asset-image.tsx';
 import { getParkingDetails } from '#/features/parking/api';
 import { EditParkingModal } from '#/features/parking/components/edit-parking-modal.tsx';
 import {
@@ -259,6 +261,33 @@ function RouteComponent() {
 
       <section className="grid gap-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(22rem,0.75fr)]">
         <div className="space-y-4">
+          {parking.assetIds.length > 0 && (
+            <Card className="rounded-lg">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <ImageIcon
+                    aria-hidden="true"
+                    className="size-4 text-muted-foreground"
+                  />
+                  Images
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 gap-2">
+                  {parking.assetIds.map((assetId) => (
+                    <AssetImage
+                      key={assetId}
+                      assetId={assetId}
+                      alt={`${parking.name} image`}
+                      width={360}
+                      height={200}
+                    />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
           <Card className="rounded-lg">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-backed asset image fetching with optional width/height sizing and browser-friendly caching (ETag + Cache-Control).
  * Introduced an `AssetImage` component for reusable thumbnails, now used in parking pages and linked-asset editing.
  * Parking details now display an Images section when assets are linked.

* **Bug Fixes**
  * Asset image responses now consistently include proper binary payload headers and ETag support for cache validation.
  * Image upload responses were updated for more direct, consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->